### PR TITLE
Fix Colcon Build Job Error

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,3 +1,6 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+
 <!-- 
 #
 # Copyright (c) 2025 Composiv.ai
@@ -13,8 +16,6 @@
 #
 -->
 
-<?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>composer</name>
   <version>0.2.0</version>


### PR DESCRIPTION
The package.xml had a comment line at the beginning. The error could be seen below:

```
Error(s) in package '/__w/composer/composer/tmp/muto/src/composer/package.xml':
The manifest contains invalid XML:
XML or text declaration not at start of entity: line 16, column 0
Error: Process completed with exit code 1.
```

Fixed it by moving the XML declaration to the top of the file