### PR TITLE
Add Missing Tests to Improve Coverage

### DIFF
--- a/test/test_composable.py
+++ b/test/test_composable.py
@@ -18,9 +18,6 @@ from composer.model.composable import Container
 
 class TestComposable(unittest.TestCase):
 
-    def setUp(self):
-        pass
-
     @patch("composer.model.composable.node")
     def test_toManifest(self, mock_node):
         self.node = Container(MagicMock(), None)

--- a/test/test_composable.py
+++ b/test/test_composable.py
@@ -1,0 +1,86 @@
+#
+# Copyright (c) 2025 Composiv.ai
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Composiv.ai - initial API and implementation
+#
+
+import unittest
+from unittest.mock import MagicMock, patch
+import rclpy
+from composer.model.composable import Container
+
+
+class TestComposable(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    @patch("composer.model.composable.node")
+    def test_toManifest(self, mock_node):
+        self.node = Container(MagicMock(), None)
+        returned_value = self.node.toManifest()
+        expected_value = {
+            "package": "",
+            "executable": "",
+            "name": "",
+            "namespace": "",
+            "node": [],
+            "output": "screen",
+            "remap": [],
+            "action": "",
+        }
+        self.assertEqual(returned_value, expected_value)
+
+    def test_resolve_namespace(self):
+        self.node = Container(MagicMock(), None)
+        self.node.namespace = "test_demo"
+        returned_value = self.node.resolve_namespace()
+        self.assertEqual(returned_value, "/test_demo//")
+
+        self.node.namespace = "test/demo/"
+        returned_value = self.node.resolve_namespace()
+        self.assertEqual(returned_value, "/test/demo//")
+
+        self.node.namespace = "test/demo"
+        returned_value = self.node.resolve_namespace()
+        self.assertEqual(returned_value, "/test/demo//")
+
+        self.node.namespace = "test/demo/core"
+        returned_value = self.node.resolve_namespace()
+        self.assertEqual(returned_value, "/test/demo/core//")
+
+    def test_eq(self):
+        self.node = Container(MagicMock(), None)
+        self.node.package = "test_pkg"
+        self.node.name = "test_name"
+        self.node.namespace = "test_namespace"
+        self.node.executable = "test_executable"
+
+        self.other_node = Container(MagicMock(), None)
+        self.other_node.package = "test_pkg"
+        self.other_node.name = "test_name"
+        self.other_node.namespace = "test_namespace"
+        self.other_node.executable = "test_executable"
+
+        returned_value = self.node.__eq__(self.other_node)
+        self.assertTrue(returned_value)
+
+        self.other_node_diff = Container(MagicMock(), None)
+        self.other_node_diff.package = "diff_test_pkg"
+        self.other_node_diff.name = "diff_test_name"
+        self.other_node_diff.namespace = "diff_test_namespace"
+        self.other_node_diff.executable = "diff_test_executable"
+
+        returned_value_diff = self.node.__eq__(self.other_node_diff)
+        self.assertFalse(returned_value_diff)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_composable.py
+++ b/test/test_composable.py
@@ -13,7 +13,6 @@
 
 import unittest
 from unittest.mock import MagicMock, patch
-import rclpy
 from composer.model.composable import Container
 
 

--- a/test/test_compose_plugin.py
+++ b/test/test_compose_plugin.py
@@ -45,7 +45,6 @@ class TestComposePlugin(unittest.TestCase):
         self.node.handle_raw_stack(stack_msg)
         self.assertEqual(self.node.incoming_stack, json.loads(stack_msg.data))
 
-
     @patch.object(MutoDefaultComposePlugin, "parse_stack")
     def test_publish_composed_stack(self, mock_parse_stack):
         self.node.incoming_stack = "MockStack"
@@ -71,7 +70,6 @@ class TestComposePlugin(unittest.TestCase):
         self.assertEqual(response.err_msg, "")
         mock_publish_composed_stack.assert_called_once()
 
-
     @patch("composer.plugins.compose_plugin.ComposePlugin")
     @patch.object(MutoDefaultComposePlugin, "publish_composed_stack")
     def test_handle_compose_start_not_set(
@@ -90,7 +88,11 @@ class TestComposePlugin(unittest.TestCase):
             "Start flag not set in compose request."
         )
 
-    @patch.object(MutoDefaultComposePlugin, "publish_composed_stack", side_effect=Exception("dummy_exception"))
+    @patch.object(
+        MutoDefaultComposePlugin,
+        "publish_composed_stack",
+        side_effect=Exception("dummy_exception"),
+    )
     @patch("composer.plugins.compose_plugin.ComposePlugin")
     def test_handle_compose_exception(self, mock_compose_plugin, mock_publish):
         request = mock_compose_plugin.Request()

--- a/test/test_introspector.py
+++ b/test/test_introspector.py
@@ -1,0 +1,83 @@
+#
+# Copyright (c) 2025 Composiv.ai
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Composiv.ai - initial API and implementation
+#
+
+import unittest
+from unittest.mock import patch, call
+import subprocess
+from composer.introspection.introspector import Introspector
+
+
+class TestIntrospector(unittest.TestCase):
+    def setUp(self):
+        self.introspector = Introspector()
+
+    @patch("subprocess.run")
+    @patch("builtins.print")
+    def test_kill_success(self, mock_print, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=["kill", "2025"], returncode=0, stdout="", stderr=""
+        )
+
+        self.introspector.kill("test_process", 2025)
+
+        mock_run.assert_called_once_with(
+            ["kill", "2025"], check=True, capture_output=True, text=True
+        )
+
+        expected_print_calls = [
+            call("Attempting to kill test_process with PID: 2025"),
+            call("Successfully killed test_process with PID: 2025"),
+        ]
+        mock_print.assert_has_calls(expected_print_calls)
+
+    @patch("subprocess.run")
+    @patch("builtins.print")
+    def test_kill_called_process_error(self, mock_print, mock_run):
+        mock_run.side_effect = subprocess.CalledProcessError(
+            returncode=1, cmd=["kill", "2025"], stderr="Permission denied"
+        )
+
+        self.introspector.kill("test_process", 2025)
+
+        mock_run.assert_called_once_with(
+            ["kill", "2025"], check=True, capture_output=True, text=True
+        )
+
+        expected_print_calls = [
+            call("Attempting to kill test_process with PID: 2025"),
+            call("Kill was not successful for test_process. Error: Permission denied"),
+        ]
+        mock_print.assert_has_calls(expected_print_calls)
+
+    @patch("subprocess.run")
+    @patch("builtins.print")
+    def test_kill_unexpected_error(self, mock_print, mock_run):
+        mock_run.side_effect = PermissionError("Operation not permitted")
+
+        self.introspector.kill("test_process", 2025)
+
+        mock_run.assert_called_once_with(
+            ["kill", "2025"], check=True, capture_output=True, text=True
+        )
+
+        expected_print_calls = [
+            call("Attempting to kill test_process with PID: 2025"),
+            call(
+                "Unexpected error while trying to kill test_process. Exception message: Operation not permitted"
+            ),
+        ]
+        mock_print.assert_has_calls(expected_print_calls)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_launch_plugin.py
+++ b/test/test_launch_plugin.py
@@ -87,7 +87,6 @@ class TestLaunchPlugin(unittest.TestCase):
         )
         self.node.get_stack(mock_stack_manifest)
 
-
     @patch("composer.plugins.launch_plugin.StackManifest")
     def test_get_stack_exception(self, mock_stack_manifest):
         mock_stack_manifest = "exception_test_string"
@@ -333,7 +332,8 @@ class TestLaunchPlugin(unittest.TestCase):
         mock_run_script.assert_not_called()
         self.assertFalse(response.success)
         self.assertEqual(
-            response.err_msg, "the JSON object must be str, bytes or bytearray, not MagicMock"
+            response.err_msg,
+            "the JSON object must be str, bytes or bytearray, not MagicMock",
         )
 
     @patch("subprocess.run")
@@ -380,7 +380,6 @@ class TestLaunchPlugin(unittest.TestCase):
         mock_run.assert_called_once_with(
             ["/mock/script/path"], check=True, capture_output=True, text=True
         )
-
 
     @patch("composer.plugins.launch_plugin.CoreTwin")
     @patch("composer.plugins.launch_plugin.LaunchPlugin")
@@ -481,7 +480,6 @@ class TestLaunchPlugin(unittest.TestCase):
         self.assertFalse(response.success)
         self.assertEqual(response.err_msg, "Script not found: True")
 
-
     @patch("composer.plugins.launch_plugin.CoreTwin")
     @patch("composer.plugins.launch_plugin.LaunchPlugin")
     def test_handle_kill_no_current_stack(self, mock_launch_plugin, mock_core_twin):
@@ -511,10 +509,10 @@ class TestLaunchPlugin(unittest.TestCase):
 
         self.node.handle_apply(request, response)
 
-        mock_stack.assert_called_once_with(manifest={'stack_name': 'mock_stack_name'})
+        mock_stack.assert_called_once_with(manifest={"stack_name": "mock_stack_name"})
         self.assertTrue(response.success)
         self.assertEqual(response.err_msg, "")
-        
+
     @patch("composer.plugins.launch_plugin.Stack")
     @patch("composer.plugins.launch_plugin.LaunchPlugin")
     def test_handle_apply_exception(self, mock_launch_plugin, mock_stack):
@@ -527,8 +525,12 @@ class TestLaunchPlugin(unittest.TestCase):
         self.node.handle_apply(request, response)
 
         self.assertFalse(response.success)
-        self.assertEqual(response.err_msg, "the JSON object must be str, bytes or bytearray, not MagicMock")
+        self.assertEqual(
+            response.err_msg,
+            "the JSON object must be str, bytes or bytearray, not MagicMock",
+        )
         mock_stack.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_launcher.py
+++ b/test/test_launcher.py
@@ -38,9 +38,6 @@ class TestLauncher(unittest.TestCase):
         self.logger_mock = MagicMock()
         rclpy.logging.get_logger = MagicMock(return_value=self.logger_mock)
 
-    def tearDown(self):
-        pass
-
     @classmethod
     def setUpClass(cls) -> None:
         rclpy.init()
@@ -141,7 +138,6 @@ class TestLauncher(unittest.TestCase):
             [call(1234, signal.SIGKILL), call(5678, signal.SIGKILL)], any_order=True
         )
         self.assertEqual(ros2launch_parent._active_nodes, [])
-        # mock_logger.get_logger().info.assert_called_with("Sent SIGKILL to process node1 (PID 1234)")
         mock_logger.get_logger().info.assert_called_with(
             "Sent SIGKILL to process node2 (PID 5678)"
         )

--- a/test/test_launcher.py
+++ b/test/test_launcher.py
@@ -31,6 +31,12 @@ class TestLauncher(unittest.TestCase):
         self._process = MagicMock()
         self._run_process = MagicMock()
         self.launch_arguments = MagicMock()
+        
+        self.launch_args = []
+        self.launch_parent = Ros2LaunchParent(self.launch_args)
+        
+        self.logger_mock = MagicMock()
+        rclpy.logging.get_logger = MagicMock(return_value=self.logger_mock)
 
     def tearDown(self):
         pass
@@ -55,23 +61,6 @@ class TestLauncher(unittest.TestCase):
         self.assertIn(("launch_css", "false"), returned_value)
         self.assertIn(("launch_sensor", "false"), returned_value)
 
-
-
-    @patch('multiprocessing.Process')
-    def test_start_method(self, mock_process):
-        ld = LaunchDescription()
-        parent = Ros2LaunchParent(ld)
-        process_mock = MagicMock()
-        mock_process.return_value = process_mock
-
-        parent.start(ld)
-
-        mock_process.assert_called_once()
-        process_mock.start.assert_called_once()
-        self.assertIsNotNone(parent._stop_event)
-        self.assertIsNotNone(parent._process)
-        self.assertEqual(mock_process.call_args[1]['daemon'], True)
-
     def test_runtime_error_parse_launch_argument(self):
         launch_list = ["launch:1"]
         with self.assertRaises(RuntimeError):
@@ -89,6 +78,21 @@ class TestLauncher(unittest.TestCase):
         self.assertIn(("launch_css", "false"), returned_value)
         self.assertIn(("launch_sensor", "true"), returned_value)
         self.assertNotIn(("la0unch_sensor", "false"), returned_value)
+        
+    @patch('multiprocessing.Process')
+    def test_start_method(self, mock_process):
+        ld = LaunchDescription()
+        parent = Ros2LaunchParent(ld)
+        process_mock = MagicMock()
+        mock_process.return_value = process_mock
+
+        parent.start(ld)
+
+        mock_process.assert_called_once()
+        process_mock.start.assert_called_once()
+        self.assertIsNotNone(parent._stop_event)
+        self.assertIsNotNone(parent._process)
+        self.assertEqual(mock_process.call_args[1]['daemon'], True)
 
     @patch("rclpy.logging")
     def test_shutdown_is_alive_true(self, mock_logger):
@@ -237,8 +241,117 @@ class TestLauncher(unittest.TestCase):
         )
         self.assertNotIn({"test_node": 24}, node_list)
         mock_logger.get_logger().info.assert_called_with("Active nodes after exit: []")
+        
+    @patch("asyncio.new_event_loop")
+    @patch("asyncio.set_event_loop")
+    def test_run_process(self, mock_set, mock_new):
+        ld = LaunchDescription()
+        node = Ros2LaunchParent(ld)
+        mock_stop_event = MagicMock()
+        node._run_process(mock_stop_event, ld)
+        mock_new.assert_called_once()
+        mock_set.assert_called_once()
+        
+
+    @patch("composer.workflow.launcher.Node")
+    @patch("launch.LaunchDescription.add_action")
+    def test_create_launch_description_for_added_nodes(self, mock_add_action, mock_node):
+        added_nodes = {
+            "node1": {
+                "name": "test_node",
+                "namespace": "/test_ns",
+                "package": "test_pkg",
+                "executable": "test_exe",
+                "parameters": [{"param1": "value1"}]
+            }
+        }
+        ld = MagicMock()
+        node = Ros2LaunchParent(ld)
+        
+        node.create_launch_description_for_added_nodes(added_nodes)
+        call_value = mock_node(package = "test_pkg", executable = "test_exe", name = "test_node", namespace = "/test_ns", output = "screen")        
+        mock_add_action.assert_called_once_with(call_value)
+        
+        
+    @patch('os.kill')
+    def test_kill_single_node(self, mock_kill):
+        with self.launch_parent._lock:
+            self.launch_parent._active_nodes.append({'node1': 1234})
+            self.launch_parent._active_nodes.append({'node2': 5678})
+
+        self.launch_parent.kill_nodes_by_name(['node1'])
+
+        mock_kill.assert_called_once_with(1234, signal.SIGKILL)
+        
+        with self.launch_parent._lock:
+            self.assertEqual(len(self.launch_parent._active_nodes), 1)
+            self.assertEqual(self.launch_parent._active_nodes[0], {'node2': 5678})
+
+        self.logger_mock.info.assert_any_call("Sent SIGKILL to process node1 (PID 1234)")
+
+    @patch('os.kill')
+    def test_kill_multiple_nodes(self, mock_kill):
+        with self.launch_parent._lock:
+            self.launch_parent._active_nodes.append({'node1': 1234})
+            self.launch_parent._active_nodes.append({'node2': 5678})
+            self.launch_parent._active_nodes.append({'node3': 9101})
+
+        self.launch_parent.kill_nodes_by_name(['node1', 'node3'])
+
+        self.assertEqual(mock_kill.call_count, 2)
+        mock_kill.assert_any_call(1234, signal.SIGKILL)
+        mock_kill.assert_any_call(9101, signal.SIGKILL)
+        
+        with self.launch_parent._lock:
+            self.assertEqual(len(self.launch_parent._active_nodes), 1)
+            self.assertEqual(self.launch_parent._active_nodes[0], {'node2': 5678})
 
 
+    @patch('os.kill', side_effect=ProcessLookupError)
+    def test_kill_already_terminated_node(self, mock_kill):
+        with self.launch_parent._lock:
+            self.launch_parent._active_nodes.append({'node1': 1234})
+
+        self.launch_parent.kill_nodes_by_name(['node1'])
+
+        mock_kill.assert_called_once_with(1234, signal.SIGKILL)
+        
+        with self.launch_parent._lock:
+            self.assertEqual(len(self.launch_parent._active_nodes), 0)
+
+        self.logger_mock.info.assert_any_call("Process node1 (PID 1234) already terminated.")
+
+    @patch('os.kill', side_effect=PermissionError("No permission"))
+    def test_kill_node_permission_error(self, mock_kill):
+        with self.launch_parent._lock:
+            self.launch_parent._active_nodes.append({'node1': 1234})
+
+        self.launch_parent.kill_nodes_by_name(['node1'])
+
+        mock_kill.assert_called_once_with(1234, signal.SIGKILL)
+        
+        with self.launch_parent._lock:
+            self.assertEqual(len(self.launch_parent._active_nodes), 0)
+
+        self.logger_mock.error.assert_called_once_with(
+            "Failed to kill process node1 (PID 1234): No permission"
+        )
+
+
+    @patch('os.kill')
+    def test_kill_nodes_with_no_active_nodes(self, mock_kill):
+        with self.launch_parent._lock:
+            self.assertEqual(len(self.launch_parent._active_nodes), 0)
+
+        self.launch_parent.kill_nodes_by_name(['node1'])
+
+        mock_kill.assert_not_called()
+
+        self.logger_mock.info.assert_any_call("No active nodes to kill.")
+
+
+        
+    
 if __name__ == "__main__":
 
     unittest.main()

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -1,0 +1,105 @@
+#
+# Copyright (c) 2025 Composiv.ai
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Composiv.ai - initial API and implementation
+#
+
+import unittest
+import rclpy
+from unittest.mock import MagicMock, patch
+
+from composer.model.node import Node
+from lifecycle_msgs.srv import GetState, GetAvailableTransitions, GetAvailableStates, ChangeState
+
+class TestNode(unittest.TestCase):
+    
+    def setUp(self):
+        self.stack_mock = MagicMock()
+        self.node_test_toManifest = {
+        "env":[
+        
+        ],
+        "param":[
+        
+        ],
+        "remap":[
+        
+        ],
+        "pkg":"test_pkg",
+        "lifecycle":"test_lifecycle",
+        "exec":"test_exec",
+        "plugin":"test_plugin",
+        "name":"test",
+        "ros_args":"",
+        "args":"",
+        "namespace":"composable",
+        "launch-prefix":None,
+        "output":"test",
+        "if":"",
+        "unless":"",
+        "action":"test_start",
+        "lifecycle":"start_test"
+        }   
+        self.node_test_toManifest["args"] = self.stack_mock.resolve_expression(self.node_test_toManifest.get('args', ''))
+
+        self.node = Node(stack=self.stack_mock, manifest = self.node_test_toManifest, container=None)
+    
+    def tearDown(self):
+        pass
+    
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+        
+    def test_toManifest(self):
+        returned_value = self.node.toManifest()
+        self.assertEqual(self.node_test_toManifest, returned_value)
+
+    @patch("rclpy.spin_until_future_complete")
+    @patch("rclpy.create_node")
+    def test_change_state(self, mock_create_node, mock_spin):
+        self.node.change_state(["configure"])
+        mock_create_node.assert_called_once_with("change_state_node")
+        mock_create_node().create_client.assert_called_once()
+        mock_spin.assert_called_once()
+        mock_create_node().destroy_node.assert_called_once()
+        
+    @patch("rclpy.spin_until_future_complete")
+    @patch("rclpy.create_node")
+    def test_get_stack(self, mock_create_node, mock_spin):
+        returned_value = self.node.get_state()
+        
+        mock_create_node.assert_called_once_with("get_state_node")
+        mock_create_node().create_client.assert_called_once_with(GetState, "/composable/test/get_state")
+        mock_create_node().create_client().call_async.assert_called_once_with(GetState.Request())
+        mock_spin.assert_called_once_with(mock_create_node(), mock_create_node().create_client().call_async(), timeout_sec=3)
+        mock_create_node().destroy_node.assert_called_once()
+        self.assertEqual(mock_create_node().create_client().call_async().result(), returned_value)
+    
+    
+    
+    @patch("rclpy.spin_until_future_complete")
+    @patch("rclpy.create_node")
+    def test_get_available_states(self, mock_create_node, mock_spin):
+        returned_value = self.node.get_available_states()
+        mock_create_node.assert_called_once_with("get_available_states_node")
+        mock_create_node().destroy_node.assert_called_once()
+        mock_create_node().create_client.assert_called_once_with(GetAvailableStates, "/composable/test/get_available_states")
+        mock_create_node().create_client().call_async.assert_called_once_with(GetAvailableStates.Request())
+        mock_spin.assert_called_once_with(mock_create_node(), mock_create_node().create_client().call_async(), timeout_sec=3)
+        self.assertEqual(mock_create_node().create_client().call_async().result().available_states, returned_value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -55,9 +55,6 @@ class TestNode(unittest.TestCase):
             stack=self.stack_mock, manifest=self.node_test_toManifest, container=None
         )
 
-    def tearDown(self):
-        pass
-
     @classmethod
     def setUpClass(cls):
         rclpy.init()

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -16,52 +16,56 @@ import rclpy
 from unittest.mock import MagicMock, patch
 
 from composer.model.node import Node
-from lifecycle_msgs.srv import GetState, GetAvailableTransitions, GetAvailableStates, ChangeState
+from lifecycle_msgs.srv import (
+    GetState,
+    GetAvailableTransitions,
+    GetAvailableStates,
+    ChangeState,
+)
+
 
 class TestNode(unittest.TestCase):
-    
+
     def setUp(self):
         self.stack_mock = MagicMock()
         self.node_test_toManifest = {
-        "env":[
-        
-        ],
-        "param":[
-        
-        ],
-        "remap":[
-        
-        ],
-        "pkg":"test_pkg",
-        "lifecycle":"test_lifecycle",
-        "exec":"test_exec",
-        "plugin":"test_plugin",
-        "name":"test",
-        "ros_args":"",
-        "args":"",
-        "namespace":"composable",
-        "launch-prefix":None,
-        "output":"test",
-        "if":"",
-        "unless":"",
-        "action":"test_start",
-        "lifecycle":"start_test"
-        }   
-        self.node_test_toManifest["args"] = self.stack_mock.resolve_expression(self.node_test_toManifest.get('args', ''))
+            "env": [],
+            "param": [],
+            "remap": [],
+            "pkg": "test_pkg",
+            "lifecycle": "test_lifecycle",
+            "exec": "test_exec",
+            "plugin": "test_plugin",
+            "name": "test",
+            "ros_args": "",
+            "args": "",
+            "namespace": "composable",
+            "launch-prefix": None,
+            "output": "test",
+            "if": "",
+            "unless": "",
+            "action": "test_start",
+            "lifecycle": "start_test",
+        }
+        self.node_test_toManifest["args"] = self.stack_mock.resolve_expression(
+            self.node_test_toManifest.get("args", "")
+        )
 
-        self.node = Node(stack=self.stack_mock, manifest = self.node_test_toManifest, container=None)
-    
+        self.node = Node(
+            stack=self.stack_mock, manifest=self.node_test_toManifest, container=None
+        )
+
     def tearDown(self):
         pass
-    
+
     @classmethod
     def setUpClass(cls):
         rclpy.init()
-        
+
     @classmethod
     def tearDownClass(cls):
         rclpy.shutdown()
-        
+
     def test_toManifest(self):
         returned_value = self.node.toManifest()
         self.assertEqual(self.node_test_toManifest, returned_value)
@@ -74,31 +78,50 @@ class TestNode(unittest.TestCase):
         mock_create_node().create_client.assert_called_once()
         mock_spin.assert_called_once()
         mock_create_node().destroy_node.assert_called_once()
-        
+
     @patch("rclpy.spin_until_future_complete")
     @patch("rclpy.create_node")
     def test_get_stack(self, mock_create_node, mock_spin):
         returned_value = self.node.get_state()
-        
+
         mock_create_node.assert_called_once_with("get_state_node")
-        mock_create_node().create_client.assert_called_once_with(GetState, "/composable/test/get_state")
-        mock_create_node().create_client().call_async.assert_called_once_with(GetState.Request())
-        mock_spin.assert_called_once_with(mock_create_node(), mock_create_node().create_client().call_async(), timeout_sec=3)
+        mock_create_node().create_client.assert_called_once_with(
+            GetState, "/composable/test/get_state"
+        )
+        mock_create_node().create_client().call_async.assert_called_once_with(
+            GetState.Request()
+        )
+        mock_spin.assert_called_once_with(
+            mock_create_node(),
+            mock_create_node().create_client().call_async(),
+            timeout_sec=3,
+        )
         mock_create_node().destroy_node.assert_called_once()
-        self.assertEqual(mock_create_node().create_client().call_async().result(), returned_value)
-    
-    
-    
+        self.assertEqual(
+            mock_create_node().create_client().call_async().result(), returned_value
+        )
+
     @patch("rclpy.spin_until_future_complete")
     @patch("rclpy.create_node")
     def test_get_available_states(self, mock_create_node, mock_spin):
         returned_value = self.node.get_available_states()
         mock_create_node.assert_called_once_with("get_available_states_node")
         mock_create_node().destroy_node.assert_called_once()
-        mock_create_node().create_client.assert_called_once_with(GetAvailableStates, "/composable/test/get_available_states")
-        mock_create_node().create_client().call_async.assert_called_once_with(GetAvailableStates.Request())
-        mock_spin.assert_called_once_with(mock_create_node(), mock_create_node().create_client().call_async(), timeout_sec=3)
-        self.assertEqual(mock_create_node().create_client().call_async().result().available_states, returned_value)
+        mock_create_node().create_client.assert_called_once_with(
+            GetAvailableStates, "/composable/test/get_available_states"
+        )
+        mock_create_node().create_client().call_async.assert_called_once_with(
+            GetAvailableStates.Request()
+        )
+        mock_spin.assert_called_once_with(
+            mock_create_node(),
+            mock_create_node().create_client().call_async(),
+            timeout_sec=3,
+        )
+        self.assertEqual(
+            mock_create_node().create_client().call_async().result().available_states,
+            returned_value,
+        )
 
 
 if __name__ == "__main__":

--- a/test/test_param.py
+++ b/test/test_param.py
@@ -1,0 +1,45 @@
+#
+# Copyright (c) 2025 Composiv.ai
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Composiv.ai - initial API and implementation
+#
+
+import unittest
+import composer.model.param as param
+from unittest.mock import MagicMock, patch
+
+
+class TestParam(unittest.TestCase):
+
+    @patch("composer.model.param.Param._resolve_value")
+    def setUp(self, mock_resolve_value):
+        self.mock_stack = MagicMock()
+        self.param = param.Param(
+            stack=self.mock_stack,
+            manifest={"name": "test-333", "from": "test", "command": "start"},
+        )
+
+    def test_parse_value(self):
+        returned1 = self.param._parse_value("TRUE")
+        returned2 = self.param._parse_value("FALSE")
+        returned3 = self.param._parse_value("1")
+        returned4 = self.param._parse_value("one")
+        self.assertTrue(returned1)
+        self.assertFalse(returned2)
+        self.assertEqual(returned3, 1)
+        self.assertEqual(returned4, "one")
+
+    def test_execute_command(self):
+        value = self.param._execute_command(command="echo muto")
+        self.assertEqual(value, "muto")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -148,16 +148,19 @@ class TestPipeline(unittest.TestCase):
         pipeline.execute_pipeline(additional_context=context)
 
         self.assertIn(
-            "compose_step", pipeline.context, 
-            "compose_step should be recorded in pipeline.context"
+            "compose_step",
+            pipeline.context,
+            "compose_step should be recorded in pipeline.context",
         )
         self.assertNotIn(
-            "native_step", pipeline.context, 
-            "native_step should not run, so not in pipeline.context"
+            "native_step",
+            pipeline.context,
+            "native_step should not run, so not in pipeline.context",
         )
         self.assertNotIn(
-            "launch_step", pipeline.context, 
-            "launch_step should not run, so not in pipeline.context"
+            "launch_step",
+            pipeline.context,
+            "launch_step should not run, so not in pipeline.context",
         )
 
     @patch("importlib.import_module")
@@ -189,12 +192,16 @@ class TestPipeline(unittest.TestCase):
                 future_mock.result.return_value = MagicMock(success=True, err_msg="")
             elif service_name == "muto_native":
                 # native_step => fails
-                future_mock.result.return_value = MagicMock(success=False, err_msg="Native error")
+                future_mock.result.return_value = MagicMock(
+                    success=False, err_msg="Native error"
+                )
             elif service_name == "muto_kill_stack":
                 # kill_step => success
                 future_mock.result.return_value = MagicMock(success=True, err_msg="")
             else:
-                future_mock.result.return_value = MagicMock(success=True, err_msg="Unreached")
+                future_mock.result.return_value = MagicMock(
+                    success=True, err_msg="Unreached"
+                )
 
             client_mock.call_async.return_value = future_mock
             return client_mock
@@ -261,7 +268,11 @@ class TestPipeline(unittest.TestCase):
         ]
 
         compensation_config = [
-            {"name": "kill_step", "service": "muto_kill_stack", "plugin": "LaunchPlugin"}
+            {
+                "name": "kill_step",
+                "service": "muto_kill_stack",
+                "plugin": "LaunchPlugin",
+            }
         ]
 
         pipeline = Pipeline(

--- a/test/test_safe_evaluator.py
+++ b/test/test_safe_evaluator.py
@@ -17,15 +17,15 @@ from composer.workflow.safe_evaluator import SafeEvaluator
 
 class TestSafeEvaluator(unittest.TestCase):
     def test_simple_condition(self):
-        context = {'step1': True}
+        context = {"step1": True}
         evaluator = SafeEvaluator(context)
         self.assertTrue(evaluator.eval_expr("step1 == True"))
         self.assertFalse(evaluator.eval_expr("step1 == False"))
 
     def test_complex_condition(self):
         context = {
-            'step1': type('Response', (object,), {'success': True}),
-            'step2': type('Response', (object,), {'output': 'desired_state'})
+            "step1": type("Response", (object,), {"success": True}),
+            "step2": type("Response", (object,), {"output": "desired_state"}),
         }
         evaluator = SafeEvaluator(context)
         condition = "step1.success == True and step2.output == 'desired_state'"
@@ -37,5 +37,6 @@ class TestSafeEvaluator(unittest.TestCase):
         with self.assertRaises(ValueError):
             evaluator.eval_expr("import sys")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/test/test_stack.py
+++ b/test/test_stack.py
@@ -58,10 +58,6 @@ class TestStack(unittest.TestCase):
         }
         self.node = Stack(manifest=self.sample_manifest)
 
-    def tearDown(self):
-        # self.node.destroy_node()
-        pass
-
     @classmethod
     def setUpClass(cls) -> None:
         rclpy.init()
@@ -365,21 +361,6 @@ class TestStack(unittest.TestCase):
         self.assertEqual(len(processed_remaps), 1)
         self.assertEqual(processed_remaps[0], ("from_topic", "to_topic"))
 
-    def test_should_node_run(self):
-        pass
-
-    def test_load_common_composables(self):
-        pass
-
-    def test_handle_composable_nodes(self):
-        pass
-
-    def test_handle_regular_nodes(self):
-        pass
-
-    def test_handle_managed_nodes(self):
-        pass
-
     @patch("composer.model.stack.Introspector")
     @patch("composer.model.stack.LaunchDescription")
     def test_launch(self, mock_launch_desc, mock_introspector):
@@ -426,9 +407,6 @@ class TestStack(unittest.TestCase):
 
         result = stack.resolve_expression("$(unknown expr)")
         self.assertEqual(result, "$(unknown expr)")
-
-    def test_resolve_param_expression(self):
-        pass
 
     def test_resolve_args(self):
         stack = Stack(manifest={})

--- a/test/test_stack.py
+++ b/test/test_stack.py
@@ -1,0 +1,462 @@
+#
+# Copyright (c) 2025 Composiv.ai
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Composiv.ai - initial API and implementation
+#
+
+import unittest
+import rclpy
+from unittest.mock import patch, MagicMock
+from composer.model.stack import Stack
+
+
+class TestStack(unittest.TestCase):
+
+    def setUp(self):
+        self.sample_manifest = {
+            "name": "test_stack",
+            "context": "test_context",
+            "stackId": "test_stack_id",
+            "param": [{"name": "param1", "value": "value1"}],
+            "arg": [{"name": "arg1", "value": "value1"}],
+            "node": [
+                {
+                    "pkg": "test_pkg",
+                    "exec": "test_exec",
+                    "name": "test_node",
+                    "namespace": "/test_ns",
+                    "output": "screen",
+                    "param": [{"name": "node_param1", "value": "node_value1"}],
+                    "remap": [{"from": "from_topic", "to": "to_topic"}],
+                    "args": "--test-arg"
+                }
+            ],
+            "composable": [
+                {
+                    "package": "test_pkg",
+                    "executable": "test_container",
+                    "name": "test_container",
+                    "namespace": "/test_ns",
+                    "nodes": [
+                        {
+                            "pkg": "test_pkg",
+                            "plugin": "test_plugin",
+                            "name": "test_composable_node",
+                            "namespace": "/test_ns",
+                            "param": [{"name": "comp_param1", "value": "comp_value1"}]
+                        }
+                    ]
+                }
+            ]
+        }
+        self.node = Stack(manifest=self.sample_manifest)
+
+    def tearDown(self):
+        # self.node.destroy_node()
+        pass
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        rclpy.shutdown()
+
+
+
+
+    def test_initialize(self):
+        stack = self.node
+        self.assertEqual(stack.name, "test_stack")
+        self.assertEqual(stack.context, "test_context")
+        self.assertEqual(stack.stackId, "test_stack_id")
+
+        self.assertEqual(len(stack.param), 1)
+        self.assertEqual(stack.param[0].name, "param1")
+        self.assertEqual(stack.param[0].value, "value1")
+
+        self.assertEqual(len(stack.arg), 1)
+        self.assertEqual(stack.arg["arg1"]["name"], "arg1")
+        self.assertEqual(stack.arg["arg1"]["value"], "value1")
+
+        self.assertEqual(len(stack.node), 1)
+        self.assertEqual(stack.node[0].pkg, "test_pkg")
+        self.assertEqual(stack.node[0].exec, "test_exec")
+
+        self.assertEqual(len(stack.composable), 1)
+        self.assertEqual(stack.composable[0].package, "test_pkg")
+        self.assertEqual(stack.composable[0].executable, "test_container")
+
+
+
+    def test_compare_nodes(self):
+        stack1 = Stack(manifest=self.sample_manifest)
+        
+        modified_manifest = self.sample_manifest.copy()
+        modified_manifest["node"].append({
+            "pkg": "new_pkg",
+            "exec": "new_exec",
+            "name": "new_node",
+            "namespace": "/new_ns"
+        })
+        stack2 = Stack(manifest=modified_manifest)
+        
+        common, difference, added = stack1.compare_nodes(stack2)
+        
+        self.assertEqual(len(common), 1)
+        self.assertEqual(list(common)[0].name, "test_node")
+        
+        self.assertEqual(len(difference), 0)
+        
+        self.assertEqual(len(added), 1)
+        self.assertEqual(list(added)[0].name, "new_node")
+
+    def test_compare_composable(self):
+        stack1 = Stack(manifest=self.sample_manifest)
+        
+        modified_manifest = self.sample_manifest.copy()
+        modified_manifest["composable"].append({
+            "package": "new_pkg",
+            "executable": "new_container",
+            "name": "new_container",
+            "namespace": "/new_ns",
+            "nodes": [
+                {
+                    "pkg": "new_pkg",
+                    "plugin": "new_plugin",
+                    "name": "new_composable_node",
+                    "namespace": "/new_ns"
+                }
+            ]
+        })
+        stack2 = Stack(manifest=modified_manifest)
+        
+        common, added, removed = stack1.compare_composable(stack2)
+        
+        self.assertEqual(len(common), 1)
+        self.assertEqual(common[0].name, "test_container")
+        
+        self.assertEqual(len(added), 1)
+        self.assertEqual(added[0].name, "new_container")
+        
+        self.assertEqual(len(removed), 0)
+
+    def test_flatten_nodes(self):
+        stack = Stack(manifest=self.sample_manifest)
+        flat_nodes = stack.flatten_nodes([])
+        
+        self.assertEqual(len(flat_nodes), 1)
+        self.assertEqual(flat_nodes[0].name, "test_node")
+
+    # def test_flatten_composable(self):
+    #     stack = Stack(manifest=self.sample_manifest)
+    #     flat_composables = stack.flatten_composable([])
+        
+    #     self.assertEqual(len(flat_composables), 1)
+    #     self.assertEqual(flat_composables[0].name, "test_container")
+    #     self.assertEqual(len(flat_composables[0].nodes), 1)
+
+    # def test_calculate_ros_params_differences(self):
+    #     stack1 = Stack(manifest=self.sample_manifest)
+        
+    #     modified_manifest = self.sample_manifest.copy()
+    #     modified_manifest["node"][0]["param"][0]["value"] = "new_value"
+    #     stack2 = Stack(manifest=modified_manifest)
+        
+    #     differences = stack1.calculate_ros_params_differences(stack1, stack2)
+        
+    #     self.assertEqual(len(differences), 1)
+    #     node_key = list(differences.keys())[0]
+    #     self.assertEqual(node_key[0], "test_node")
+    #     self.assertEqual(differences[node_key][0]["key"], "node_param1")
+    #     self.assertEqual(differences[node_key][0]["in_node1"], "node_value1")
+    #     self.assertEqual(differences[node_key][0]["in_node2"], "new_value")
+
+    def test_compare_ros_params(self):
+        params1 = [{"param1": "value1"}, {"param2": "value2"}]
+        params2 = [{"param1": "new_value1"}, {"param3": "value3"}]
+        
+        differences = Stack.compare_ros_params(params1, params2)
+        
+        self.assertEqual(len(differences), 3)
+        param_names = {diff["key"] for diff in differences}
+        self.assertIn("param1", param_names)
+        self.assertIn("param2", param_names)
+        self.assertIn("param3", param_names)
+
+    def test_merge(self):
+        stack1 = Stack(manifest=self.sample_manifest)
+        
+        modified_manifest = self.sample_manifest.copy()
+        modified_manifest["node"].append({
+            "pkg": "new_pkg",
+            "exec": "new_exec",
+            "name": "new_node",
+            "namespace": "/new_ns"
+        })
+        stack2 = Stack(manifest=modified_manifest)
+        
+        merged_stack = stack1.merge(stack2)
+        
+        self.assertEqual(len(merged_stack.node), 2)
+        node_names = {n.name for n in merged_stack.node}
+        self.assertIn("test_node", node_names)
+        self.assertIn("new_node", node_names)
+
+    def test_merge_attributes(self):
+        stack1 = Stack(manifest=self.sample_manifest)
+        stack2 = Stack(manifest={"name": "new_name", "context": "new_context", "stackId": "new_id"})
+        merged = Stack(manifest={})
+        
+        stack1._merge_attributes(merged, stack2)
+        
+        self.assertEqual(merged.name, "new_name")
+        self.assertEqual(merged.context, "new_context")
+        self.assertEqual(merged.stackId, "new_id")
+
+    # def test_merge_nodes(self):
+    #     stack1 = Stack(manifest=self.sample_manifest)
+    #     modified_manifest = self.sample_manifest.copy()
+    #     modified_manifest["node"].append({
+    #         "pkg": "new_pkg",
+    #         "exec": "new_exec",
+    #         "name": "new_node",
+    #         "namespace": "/new_ns"
+    #     })
+    #     stack2 = Stack(manifest=modified_manifest)
+    #     merged = Stack(manifest={})
+        
+    #     stack1._merge_nodes(merged, stack2)
+        
+    #     self.assertEqual(len(merged.node), 2)
+    #     node_actions = {n.name: n.action for n in merged.node}
+    #     self.assertEqual(node_actions["test_node"], "stop")
+    #     self.assertEqual(node_actions["new_node"], "start")
+
+    def test_merge_composables(self):
+        stack1 = Stack(manifest=self.sample_manifest)
+        modified_manifest = self.sample_manifest.copy()
+        modified_manifest["composable"].append({
+            "package": "new_pkg",
+            "executable": "new_container",
+            "name": "new_container",
+            "namespace": "/new_ns"
+        })
+        stack2 = Stack(manifest=modified_manifest)
+        merged = Stack(manifest={})
+        
+        stack1._merge_composables(merged, stack2)
+        
+        self.assertEqual(len(merged.composable), 2)
+        container_names = {c.name for c in merged.composable}
+        self.assertIn("test_container", container_names)
+        self.assertIn("new_container", container_names)
+
+    # def test_compare_and_mark_nodes(self):
+    #     stack = Stack(manifest=self.sample_manifest)
+    #     current_container = stack.composable[0]
+    #     other_container = MagicMock()
+    #     other_container.nodes = [
+    #         MagicMock(namespace="/test_ns", name="test_composable_node", action=None),
+    #         MagicMock(namespace="/test_ns", name="new_node", action=None)
+    #     ]
+    #     merged = Stack(manifest={})
+        
+    #     stack.compare_and_mark_nodes(current_container, other_container, merged)
+        
+    #     node_actions = {n.name: n.action for n in other_container.nodes}
+    #     self.assertEqual(node_actions["test_composable_node"], "none")
+    #     self.assertEqual(node_actions["new_node"], "start")
+
+    def test_merge_params(self):
+        stack1 = Stack(manifest=self.sample_manifest)
+        modified_manifest = self.sample_manifest.copy()
+        modified_manifest["param"].append({"name": "new_param", "value": "new_value"})
+        stack2 = Stack(manifest=modified_manifest)
+        merged = Stack(manifest={})
+        
+        stack1._merge_params(merged, stack2)
+        
+        self.assertEqual(len(merged.param), 2)
+        param_names = {p.name for p in merged.param}
+        self.assertIn("param1", param_names)
+        self.assertIn("new_param", param_names)
+
+    @patch('composer.model.stack.rclpy')
+    def test_get_active_nodes(self, mock_rclpy):
+        mock_node = MagicMock()
+        mock_node.get_node_names_and_namespaces.return_value = [("/ns", "node1"), ("/", "node2")]
+        mock_rclpy.create_node.return_value = mock_node
+        
+        stack = Stack(manifest=self.sample_manifest)
+        active_nodes = stack.get_active_nodes()
+        
+        self.assertEqual(len(active_nodes), 2)
+        self.assertIn(("/ns", "node1"), active_nodes)
+        self.assertIn(("/", "node2"), active_nodes)
+        mock_rclpy.create_node.assert_called_once_with('get_active_nodes', enable_rosout=False)
+        mock_node.destroy_node.assert_called_once()
+
+    @patch('composer.model.stack.Introspector')
+    def test_kill_all(self, mock_introspector):
+        mock_launcher = MagicMock()
+        mock_launcher._active_nodes = [{"node1": 1234}, {"node2": 5678}]
+        
+        stack = Stack(manifest=self.sample_manifest)
+        stack.kill_all(mock_launcher)
+        
+        mock_introspector.return_value.kill.assert_any_call("node1", 1234)
+        mock_introspector.return_value.kill.assert_any_call("node2", 5678)
+
+    @patch('composer.model.stack.Introspector')
+    def test_kill_diff(self, mock_introspector):
+        mock_launcher = MagicMock()
+        mock_launcher._active_nodes = [{"test_exec": 1234}, {"other_exec": 5678}]
+        
+        stack = Stack(manifest=self.sample_manifest)
+        test_node = stack.node[0]
+        test_node.action = "stop"
+        
+        stack.kill_diff(mock_launcher, stack)
+        
+        mock_introspector.return_value.kill.assert_called_once_with("test_exec", 1234)
+
+    @patch('composer.model.stack.subprocess.run')
+    def test_change_params_at_runtime(self, mock_run):
+        param_differences = {
+            ("node1", "node2"): [
+                {"key": "param1", "in_node1": "value1", "in_node2": "value2"}
+            ]
+        }
+        
+        stack = Stack(manifest=self.sample_manifest)
+        stack.change_params_at_runtime(param_differences)
+        
+        mock_run.assert_called_once_with(['ros2', 'param', 'set', 'node1', 'param1', 'value1'])
+
+    def test_toShallowManifest(self):
+        stack = Stack(manifest=self.sample_manifest)
+        manifest = stack.toShallowManifest()
+        
+        self.assertEqual(manifest["name"], "test_stack")
+        self.assertEqual(manifest["context"], "test_context")
+        self.assertEqual(manifest["stackId"], "test_stack_id")
+        self.assertEqual(manifest["param"], [])
+        self.assertEqual(manifest["arg"], [])
+        self.assertEqual(manifest["stack"], [])
+        self.assertEqual(manifest["composable"], [])
+        self.assertEqual(manifest["node"], [])
+
+    def test_toManifest(self):
+        stack = Stack(manifest=self.sample_manifest)
+        manifest = stack.toManifest()
+        
+        self.assertEqual(manifest["name"], "test_stack")
+        self.assertEqual(manifest["context"], "test_context")
+        self.assertEqual(manifest["stackId"], "test_stack_id")
+        
+        self.assertEqual(len(manifest["param"]), 1)
+        self.assertEqual(manifest["param"][0]["name"], "param1")
+        self.assertEqual(manifest["param"][0]["value"], "value1")
+        
+        self.assertEqual(len(manifest["node"]), 1)
+        self.assertEqual(manifest["node"][0]["name"], "test_node")
+        
+        self.assertEqual(len(manifest["composable"]), 1)
+        self.assertEqual(manifest["composable"][0]["name"], "test_container")
+
+    def test_process_remaps(self):
+        stack = Stack(manifest=self.sample_manifest)
+        remaps_config = [{"from": "from_topic", "to": "to_topic"}]
+        
+        processed_remaps = stack.process_remaps(remaps_config)
+        
+        self.assertEqual(len(processed_remaps), 1)
+        self.assertEqual(processed_remaps[0], ("from_topic", "to_topic"))
+
+    def test_should_node_run(self):
+        pass
+
+    def test_load_common_composables(self):
+        pass
+
+    def test_handle_composable_nodes(self):
+        pass
+
+    def test_handle_regular_nodes(self):
+        pass
+
+    def test_handle_managed_nodes(self):
+        pass
+
+    @patch('composer.model.stack.Introspector')
+    @patch('composer.model.stack.LaunchDescription')
+    def test_launch(self, mock_launch_desc, mock_introspector):
+        stack = Stack(manifest=self.sample_manifest)
+        mock_launcher = MagicMock()
+        
+        with patch('composer.model.stack.ComposableNodeContainer'), \
+             patch('composer.model.stack.ComposableNode'), \
+             patch('composer.model.stack.Node'):
+            stack.launch(mock_launcher)
+        
+        mock_launcher.start.assert_called_once()
+
+    @patch('composer.model.stack.Introspector')
+    @patch('composer.model.stack.LaunchDescription')
+    def test_apply(self, mock_launch_desc, mock_introspector):
+        stack = Stack(manifest=self.sample_manifest)
+        mock_launcher = MagicMock()
+        
+        with patch.object(Stack, 'kill_diff') as mock_kill_diff, \
+             patch.object(Stack, 'launch') as mock_launch:
+            stack.apply(mock_launcher)
+        
+        mock_kill_diff.assert_called_once_with(mock_launcher, stack)
+        mock_launch.assert_called_once_with(mock_launcher)
+
+    def test_resolve_expression(self):
+        stack = Stack(manifest=self.sample_manifest)
+        
+        with patch('composer.model.stack.get_package_share_directory', return_value='/fake/path'):
+            result = stack.resolve_expression("$(find test_pkg)")
+            self.assertEqual(result, "/fake/path")
+        
+        with patch.dict('os.environ', {'TEST_VAR': 'test_value'}):
+            result = stack.resolve_expression("$(env TEST_VAR)")
+            self.assertEqual(result, "test_value")
+        
+        result = stack.resolve_expression("$(arg arg1)")
+        self.assertEqual(result, "value1")
+        
+        result = stack.resolve_expression("$(unknown expr)")
+        self.assertEqual(result, "$(unknown expr)")
+
+    def test_resolve_param_expression(self):
+        pass
+
+    def test_resolve_args(self):
+        stack = Stack(manifest={})
+        args = [{"name": "test_arg", "value": "test_value"}]
+        
+        resolved_args = stack.resolve_args(args)
+        
+        self.assertEqual(len(resolved_args), 1)
+        self.assertEqual(resolved_args["test_arg"]["name"], "test_arg")
+        self.assertEqual(resolved_args["test_arg"]["value"], "test_value")
+
+
+
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_stack.py
+++ b/test/test_stack.py
@@ -35,7 +35,7 @@ class TestStack(unittest.TestCase):
                     "output": "screen",
                     "param": [{"name": "node_param1", "value": "node_value1"}],
                     "remap": [{"from": "from_topic", "to": "to_topic"}],
-                    "args": "--test-arg"
+                    "args": "--test-arg",
                 }
             ],
             "composable": [
@@ -44,17 +44,17 @@ class TestStack(unittest.TestCase):
                     "executable": "test_container",
                     "name": "test_container",
                     "namespace": "/test_ns",
-                    "nodes": [
+                    "node": [
                         {
                             "pkg": "test_pkg",
                             "plugin": "test_plugin",
                             "name": "test_composable_node",
                             "namespace": "/test_ns",
-                            "param": [{"name": "comp_param1", "value": "comp_value1"}]
+                            "param": [{"name": "comp_param1", "value": "comp_value1"}],
                         }
-                    ]
+                    ],
                 }
-            ]
+            ],
         }
         self.node = Stack(manifest=self.sample_manifest)
 
@@ -69,9 +69,6 @@ class TestStack(unittest.TestCase):
     @classmethod
     def tearDownClass(cls) -> None:
         rclpy.shutdown()
-
-
-
 
     def test_initialize(self):
         stack = self.node
@@ -95,97 +92,84 @@ class TestStack(unittest.TestCase):
         self.assertEqual(stack.composable[0].package, "test_pkg")
         self.assertEqual(stack.composable[0].executable, "test_container")
 
-
-
     def test_compare_nodes(self):
         stack1 = Stack(manifest=self.sample_manifest)
-        
+
         modified_manifest = self.sample_manifest.copy()
-        modified_manifest["node"].append({
-            "pkg": "new_pkg",
-            "exec": "new_exec",
-            "name": "new_node",
-            "namespace": "/new_ns"
-        })
+        modified_manifest["node"].append(
+            {
+                "pkg": "new_pkg",
+                "exec": "new_exec",
+                "name": "new_node",
+                "namespace": "/new_ns",
+            }
+        )
         stack2 = Stack(manifest=modified_manifest)
-        
+
         common, difference, added = stack1.compare_nodes(stack2)
-        
+
         self.assertEqual(len(common), 1)
         self.assertEqual(list(common)[0].name, "test_node")
-        
+
         self.assertEqual(len(difference), 0)
-        
+
         self.assertEqual(len(added), 1)
         self.assertEqual(list(added)[0].name, "new_node")
 
     def test_compare_composable(self):
         stack1 = Stack(manifest=self.sample_manifest)
-        
+
         modified_manifest = self.sample_manifest.copy()
-        modified_manifest["composable"].append({
-            "package": "new_pkg",
-            "executable": "new_container",
-            "name": "new_container",
-            "namespace": "/new_ns",
-            "nodes": [
-                {
-                    "pkg": "new_pkg",
-                    "plugin": "new_plugin",
-                    "name": "new_composable_node",
-                    "namespace": "/new_ns"
-                }
-            ]
-        })
+        modified_manifest["composable"].append(
+            {
+                "package": "new_pkg",
+                "executable": "new_container",
+                "name": "new_container",
+                "namespace": "/new_ns",
+                "nodes": [
+                    {
+                        "pkg": "new_pkg",
+                        "plugin": "new_plugin",
+                        "name": "new_composable_node",
+                        "namespace": "/new_ns",
+                    }
+                ],
+            }
+        )
         stack2 = Stack(manifest=modified_manifest)
-        
+
         common, added, removed = stack1.compare_composable(stack2)
-        
+
         self.assertEqual(len(common), 1)
         self.assertEqual(common[0].name, "test_container")
-        
+
         self.assertEqual(len(added), 1)
         self.assertEqual(added[0].name, "new_container")
-        
+
         self.assertEqual(len(removed), 0)
 
     def test_flatten_nodes(self):
         stack = Stack(manifest=self.sample_manifest)
         flat_nodes = stack.flatten_nodes([])
-        
+
         self.assertEqual(len(flat_nodes), 1)
         self.assertEqual(flat_nodes[0].name, "test_node")
 
-    # def test_flatten_composable(self):
-    #     stack = Stack(manifest=self.sample_manifest)
-    #     flat_composables = stack.flatten_composable([])
-        
-    #     self.assertEqual(len(flat_composables), 1)
-    #     self.assertEqual(flat_composables[0].name, "test_container")
-    #     self.assertEqual(len(flat_composables[0].nodes), 1)
+    def test_flatten_composable(self):
+        stack = Stack(manifest=self.sample_manifest)
+        flat_composables = stack.flatten_composable([])
 
-    # def test_calculate_ros_params_differences(self):
-    #     stack1 = Stack(manifest=self.sample_manifest)
-        
-    #     modified_manifest = self.sample_manifest.copy()
-    #     modified_manifest["node"][0]["param"][0]["value"] = "new_value"
-    #     stack2 = Stack(manifest=modified_manifest)
-        
-    #     differences = stack1.calculate_ros_params_differences(stack1, stack2)
-        
-    #     self.assertEqual(len(differences), 1)
-    #     node_key = list(differences.keys())[0]
-    #     self.assertEqual(node_key[0], "test_node")
-    #     self.assertEqual(differences[node_key][0]["key"], "node_param1")
-    #     self.assertEqual(differences[node_key][0]["in_node1"], "node_value1")
-    #     self.assertEqual(differences[node_key][0]["in_node2"], "new_value")
+        self.assertEqual(len(flat_composables), 1)
+        self.assertEqual(flat_composables[0].name, "test_container")
+        self.assertEqual(len(flat_composables[0].nodes), 1)
+        print(flat_composables[0].nodes)
 
     def test_compare_ros_params(self):
         params1 = [{"param1": "value1"}, {"param2": "value2"}]
         params2 = [{"param1": "new_value1"}, {"param3": "value3"}]
-        
+
         differences = Stack.compare_ros_params(params1, params2)
-        
+
         self.assertEqual(len(differences), 3)
         param_names = {diff["key"] for diff in differences}
         self.assertIn("param1", param_names)
@@ -194,18 +178,20 @@ class TestStack(unittest.TestCase):
 
     def test_merge(self):
         stack1 = Stack(manifest=self.sample_manifest)
-        
+
         modified_manifest = self.sample_manifest.copy()
-        modified_manifest["node"].append({
-            "pkg": "new_pkg",
-            "exec": "new_exec",
-            "name": "new_node",
-            "namespace": "/new_ns"
-        })
+        modified_manifest["node"].append(
+            {
+                "pkg": "new_pkg",
+                "exec": "new_exec",
+                "name": "new_node",
+                "namespace": "/new_ns",
+            }
+        )
         stack2 = Stack(manifest=modified_manifest)
-        
+
         merged_stack = stack1.merge(stack2)
-        
+
         self.assertEqual(len(merged_stack.node), 2)
         node_names = {n.name for n in merged_stack.node}
         self.assertIn("test_node", node_names)
@@ -213,68 +199,58 @@ class TestStack(unittest.TestCase):
 
     def test_merge_attributes(self):
         stack1 = Stack(manifest=self.sample_manifest)
-        stack2 = Stack(manifest={"name": "new_name", "context": "new_context", "stackId": "new_id"})
+        stack2 = Stack(
+            manifest={"name": "new_name", "context": "new_context", "stackId": "new_id"}
+        )
         merged = Stack(manifest={})
-        
+
         stack1._merge_attributes(merged, stack2)
-        
+
         self.assertEqual(merged.name, "new_name")
         self.assertEqual(merged.context, "new_context")
         self.assertEqual(merged.stackId, "new_id")
 
-    # def test_merge_nodes(self):
-    #     stack1 = Stack(manifest=self.sample_manifest)
-    #     modified_manifest = self.sample_manifest.copy()
-    #     modified_manifest["node"].append({
-    #         "pkg": "new_pkg",
-    #         "exec": "new_exec",
-    #         "name": "new_node",
-    #         "namespace": "/new_ns"
-    #     })
-    #     stack2 = Stack(manifest=modified_manifest)
-    #     merged = Stack(manifest={})
-        
-    #     stack1._merge_nodes(merged, stack2)
-        
-    #     self.assertEqual(len(merged.node), 2)
-    #     node_actions = {n.name: n.action for n in merged.node}
-    #     self.assertEqual(node_actions["test_node"], "stop")
-    #     self.assertEqual(node_actions["new_node"], "start")
+    def test_merge_nodes(self):
+        stack1 = Stack(manifest=self.sample_manifest)
+        modified_manifest = self.sample_manifest.copy()
+        modified_manifest["node"].append(
+            {
+                "pkg": "new_pkg",
+                "exec": "new_exec",
+                "name": "new_node",
+                "namespace": "/new_ns",
+            }
+        )
+        stack2 = Stack(manifest=modified_manifest)
+        merged = Stack(manifest={})
+
+        stack1._merge_nodes(merged, stack2)
+
+        self.assertEqual(len(merged.node), 2)
+        node_actions = {n.name: n.action for n in merged.node}
+        self.assertEqual(node_actions["test_node"], "none")
+        self.assertEqual(node_actions["new_node"], "start")
 
     def test_merge_composables(self):
         stack1 = Stack(manifest=self.sample_manifest)
         modified_manifest = self.sample_manifest.copy()
-        modified_manifest["composable"].append({
-            "package": "new_pkg",
-            "executable": "new_container",
-            "name": "new_container",
-            "namespace": "/new_ns"
-        })
+        modified_manifest["composable"].append(
+            {
+                "package": "new_pkg",
+                "executable": "new_container",
+                "name": "new_container",
+                "namespace": "/new_ns",
+            }
+        )
         stack2 = Stack(manifest=modified_manifest)
         merged = Stack(manifest={})
-        
+
         stack1._merge_composables(merged, stack2)
-        
+
         self.assertEqual(len(merged.composable), 2)
         container_names = {c.name for c in merged.composable}
         self.assertIn("test_container", container_names)
         self.assertIn("new_container", container_names)
-
-    # def test_compare_and_mark_nodes(self):
-    #     stack = Stack(manifest=self.sample_manifest)
-    #     current_container = stack.composable[0]
-    #     other_container = MagicMock()
-    #     other_container.nodes = [
-    #         MagicMock(namespace="/test_ns", name="test_composable_node", action=None),
-    #         MagicMock(namespace="/test_ns", name="new_node", action=None)
-    #     ]
-    #     merged = Stack(manifest={})
-        
-    #     stack.compare_and_mark_nodes(current_container, other_container, merged)
-        
-    #     node_actions = {n.name: n.action for n in other_container.nodes}
-    #     self.assertEqual(node_actions["test_composable_node"], "none")
-    #     self.assertEqual(node_actions["new_node"], "start")
 
     def test_merge_params(self):
         stack1 = Stack(manifest=self.sample_manifest)
@@ -282,70 +258,77 @@ class TestStack(unittest.TestCase):
         modified_manifest["param"].append({"name": "new_param", "value": "new_value"})
         stack2 = Stack(manifest=modified_manifest)
         merged = Stack(manifest={})
-        
+
         stack1._merge_params(merged, stack2)
-        
+
         self.assertEqual(len(merged.param), 2)
         param_names = {p.name for p in merged.param}
         self.assertIn("param1", param_names)
         self.assertIn("new_param", param_names)
 
-    @patch('composer.model.stack.rclpy')
+    @patch("composer.model.stack.rclpy")
     def test_get_active_nodes(self, mock_rclpy):
         mock_node = MagicMock()
-        mock_node.get_node_names_and_namespaces.return_value = [("/ns", "node1"), ("/", "node2")]
+        mock_node.get_node_names_and_namespaces.return_value = [
+            ("/ns", "node1"),
+            ("/", "node2"),
+        ]
         mock_rclpy.create_node.return_value = mock_node
-        
+
         stack = Stack(manifest=self.sample_manifest)
         active_nodes = stack.get_active_nodes()
-        
+
         self.assertEqual(len(active_nodes), 2)
         self.assertIn(("/ns", "node1"), active_nodes)
         self.assertIn(("/", "node2"), active_nodes)
-        mock_rclpy.create_node.assert_called_once_with('get_active_nodes', enable_rosout=False)
+        mock_rclpy.create_node.assert_called_once_with(
+            "get_active_nodes", enable_rosout=False
+        )
         mock_node.destroy_node.assert_called_once()
 
-    @patch('composer.model.stack.Introspector')
+    @patch("composer.model.stack.Introspector")
     def test_kill_all(self, mock_introspector):
         mock_launcher = MagicMock()
         mock_launcher._active_nodes = [{"node1": 1234}, {"node2": 5678}]
-        
+
         stack = Stack(manifest=self.sample_manifest)
         stack.kill_all(mock_launcher)
-        
+
         mock_introspector.return_value.kill.assert_any_call("node1", 1234)
         mock_introspector.return_value.kill.assert_any_call("node2", 5678)
 
-    @patch('composer.model.stack.Introspector')
+    @patch("composer.model.stack.Introspector")
     def test_kill_diff(self, mock_introspector):
         mock_launcher = MagicMock()
         mock_launcher._active_nodes = [{"test_exec": 1234}, {"other_exec": 5678}]
-        
+
         stack = Stack(manifest=self.sample_manifest)
         test_node = stack.node[0]
         test_node.action = "stop"
-        
+
         stack.kill_diff(mock_launcher, stack)
-        
+
         mock_introspector.return_value.kill.assert_called_once_with("test_exec", 1234)
 
-    @patch('composer.model.stack.subprocess.run')
+    @patch("composer.model.stack.subprocess.run")
     def test_change_params_at_runtime(self, mock_run):
         param_differences = {
             ("node1", "node2"): [
                 {"key": "param1", "in_node1": "value1", "in_node2": "value2"}
             ]
         }
-        
+
         stack = Stack(manifest=self.sample_manifest)
         stack.change_params_at_runtime(param_differences)
-        
-        mock_run.assert_called_once_with(['ros2', 'param', 'set', 'node1', 'param1', 'value1'])
+
+        mock_run.assert_called_once_with(
+            ["ros2", "param", "set", "node1", "param1", "value1"]
+        )
 
     def test_toShallowManifest(self):
         stack = Stack(manifest=self.sample_manifest)
         manifest = stack.toShallowManifest()
-        
+
         self.assertEqual(manifest["name"], "test_stack")
         self.assertEqual(manifest["context"], "test_context")
         self.assertEqual(manifest["stackId"], "test_stack_id")
@@ -358,27 +341,27 @@ class TestStack(unittest.TestCase):
     def test_toManifest(self):
         stack = Stack(manifest=self.sample_manifest)
         manifest = stack.toManifest()
-        
+
         self.assertEqual(manifest["name"], "test_stack")
         self.assertEqual(manifest["context"], "test_context")
         self.assertEqual(manifest["stackId"], "test_stack_id")
-        
+
         self.assertEqual(len(manifest["param"]), 1)
         self.assertEqual(manifest["param"][0]["name"], "param1")
         self.assertEqual(manifest["param"][0]["value"], "value1")
-        
+
         self.assertEqual(len(manifest["node"]), 1)
         self.assertEqual(manifest["node"][0]["name"], "test_node")
-        
+
         self.assertEqual(len(manifest["composable"]), 1)
         self.assertEqual(manifest["composable"][0]["name"], "test_container")
 
     def test_process_remaps(self):
         stack = Stack(manifest=self.sample_manifest)
         remaps_config = [{"from": "from_topic", "to": "to_topic"}]
-        
+
         processed_remaps = stack.process_remaps(remaps_config)
-        
+
         self.assertEqual(len(processed_remaps), 1)
         self.assertEqual(processed_remaps[0], ("from_topic", "to_topic"))
 
@@ -397,46 +380,50 @@ class TestStack(unittest.TestCase):
     def test_handle_managed_nodes(self):
         pass
 
-    @patch('composer.model.stack.Introspector')
-    @patch('composer.model.stack.LaunchDescription')
+    @patch("composer.model.stack.Introspector")
+    @patch("composer.model.stack.LaunchDescription")
     def test_launch(self, mock_launch_desc, mock_introspector):
         stack = Stack(manifest=self.sample_manifest)
         mock_launcher = MagicMock()
-        
-        with patch('composer.model.stack.ComposableNodeContainer'), \
-             patch('composer.model.stack.ComposableNode'), \
-             patch('composer.model.stack.Node'):
+
+        with patch("composer.model.stack.ComposableNodeContainer"), patch(
+            "composer.model.stack.ComposableNode"
+        ), patch("composer.model.stack.Node"):
             stack.launch(mock_launcher)
-        
+
         mock_launcher.start.assert_called_once()
 
-    @patch('composer.model.stack.Introspector')
-    @patch('composer.model.stack.LaunchDescription')
+    @patch("composer.model.stack.Introspector")
+    @patch("composer.model.stack.LaunchDescription")
     def test_apply(self, mock_launch_desc, mock_introspector):
         stack = Stack(manifest=self.sample_manifest)
         mock_launcher = MagicMock()
-        
-        with patch.object(Stack, 'kill_diff') as mock_kill_diff, \
-             patch.object(Stack, 'launch') as mock_launch:
+
+        with patch.object(Stack, "kill_diff") as mock_kill_diff, patch.object(
+            Stack, "launch"
+        ) as mock_launch:
             stack.apply(mock_launcher)
-        
+
         mock_kill_diff.assert_called_once_with(mock_launcher, stack)
         mock_launch.assert_called_once_with(mock_launcher)
 
     def test_resolve_expression(self):
         stack = Stack(manifest=self.sample_manifest)
-        
-        with patch('composer.model.stack.get_package_share_directory', return_value='/fake/path'):
+
+        with patch(
+            "composer.model.stack.get_package_share_directory",
+            return_value="/fake/path",
+        ):
             result = stack.resolve_expression("$(find test_pkg)")
             self.assertEqual(result, "/fake/path")
-        
-        with patch.dict('os.environ', {'TEST_VAR': 'test_value'}):
+
+        with patch.dict("os.environ", {"TEST_VAR": "test_value"}):
             result = stack.resolve_expression("$(env TEST_VAR)")
             self.assertEqual(result, "test_value")
-        
+
         result = stack.resolve_expression("$(arg arg1)")
         self.assertEqual(result, "value1")
-        
+
         result = stack.resolve_expression("$(unknown expr)")
         self.assertEqual(result, "$(unknown expr)")
 
@@ -446,17 +433,13 @@ class TestStack(unittest.TestCase):
     def test_resolve_args(self):
         stack = Stack(manifest={})
         args = [{"name": "test_arg", "value": "test_value"}]
-        
+
         resolved_args = stack.resolve_args(args)
-        
+
         self.assertEqual(len(resolved_args), 1)
         self.assertEqual(resolved_args["test_arg"]["name"], "test_arg")
         self.assertEqual(resolved_args["test_arg"]["value"], "test_value")
 
 
-
-
-
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/test_traverser.py
+++ b/test/test_traverser.py
@@ -1,0 +1,85 @@
+import unittest
+
+from launch_ros.actions import Node
+from launch_ros.descriptions import ComposableNode
+
+from composer.introspection.traverser import recursively_extract_entities, resolve_substitutions
+from launch import LaunchContext
+from launch.actions import (DeclareLaunchArgument, GroupAction)
+from launch.substitutions import LaunchConfiguration, TextSubstitution
+
+
+class TestResolveSubstitutions(unittest.TestCase):
+    def test_resolve_text_substitution_list(self):
+        context = LaunchContext()
+        subs = [TextSubstitution(text="test"), TextSubstitution(text="_node")]
+        result = resolve_substitutions(context, subs)
+        self.assertEqual(result, "test_node")
+
+    def test_resolve_launch_configuration(self):
+        context = LaunchContext()
+        DeclareLaunchArgument("test_arg", default_value="test_value").execute(context)
+        subs = [LaunchConfiguration("test_arg")]
+        result = resolve_substitutions(context, subs)
+        self.assertEqual(result, "test_value")
+
+    def test_resolve_string(self):
+        context = LaunchContext()
+        result = resolve_substitutions(context, "test_node")
+        self.assertEqual(result, "test_node")
+
+    def test_resolve_tuple(self):
+        context = LaunchContext()
+        subs = (TextSubstitution(text="tuple"),)
+        result = resolve_substitutions(context, subs)
+        self.assertEqual(result, "tuple")
+
+
+class TestRecursiveExtractEntities(unittest.TestCase):
+    def setUp(self):
+        self.context = LaunchContext()
+        self.nodes = []
+        self.composable_nodes = []
+        self.containers = []
+
+    def test_simple_node_extraction(self):
+        node = Node(package="test_pkg", executable="test_exe")
+        recursively_extract_entities(
+            [node], self.context, self.nodes, self.composable_nodes, self.containers
+        )
+        self.assertEqual(len(self.nodes), 1)
+        self.assertIsInstance(self.nodes[0], Node)
+
+    def test_composable_node_extraction(self):
+        cnode = ComposableNode(
+            package="test_pkg", plugin="test_plugin", name="test_node"
+        )
+        recursively_extract_entities(
+            [cnode], self.context, self.nodes, self.composable_nodes, self.containers
+        )
+        self.assertEqual(len(self.composable_nodes), 1)
+        self.assertIsInstance(self.composable_nodes[0], ComposableNode)
+
+    def test_group_action_extraction(self):
+        node = Node(package="test_pkg", executable="test_exe")
+        group = GroupAction([node])
+        recursively_extract_entities(
+            [group], self.context, self.nodes, self.composable_nodes, self.containers
+        )
+        self.assertEqual(len(self.nodes), 1)
+        self.assertIsInstance(self.nodes[0], Node)
+
+    def test_duplicate_entity_handling(self):
+        node = Node(package="test_pkg", executable="test_exe")
+        recursively_extract_entities(
+            [node, node],
+            self.context,
+            self.nodes,
+            self.composable_nodes,
+            self.containers,
+        )
+        self.assertEqual(len(self.nodes), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_traverser.py
+++ b/test/test_traverser.py
@@ -1,11 +1,27 @@
+#
+# Copyright (c) 2025 Composiv.ai
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Composiv.ai - initial API and implementation
+#
+
 import unittest
 
 from launch_ros.actions import Node
 from launch_ros.descriptions import ComposableNode
 
-from composer.introspection.traverser import recursively_extract_entities, resolve_substitutions
+from composer.introspection.traverser import (
+    recursively_extract_entities,
+    resolve_substitutions,
+)
 from launch import LaunchContext
-from launch.actions import (DeclareLaunchArgument, GroupAction)
+from launch.actions import DeclareLaunchArgument, GroupAction
 from launch.substitutions import LaunchConfiguration, TextSubstitution
 
 


### PR DESCRIPTION
This PR improves the test coverage for the composer, targeting at least 80% overall coverage.

Added tests
- composable, introspector, launcher, muto_composer, node, param, stack, traverser

Format changes
- compose_plugin, launch_plugin, pipeline, safe_evaluator
