### PR TITLE
[Feature- Manifests]: Updated syntax for stack manifests types and updates to pipeline data flow 

### DIFF
--- a/composer/model/stack.py
+++ b/composer/model/stack.py
@@ -404,7 +404,7 @@ class Stack():
         """
         return [(rmp['from'], rmp['to']) for rmp in remaps_config] if remaps_config else []
 
-    def should_node_run(self, node):
+    def should_node_run(self, node, launcher):
         """Check if a node should run. 
         This method clears the situation where a 
         node has NOACTION but it isn't running
@@ -412,12 +412,13 @@ class Stack():
 
         Args:
             node (object): The node object.
+            launcher (object): The launcher object.
 
         Returns:
             bool: True if the node should run, False otherwise.
         """
         active_nodes = [(active[1] if active[1] != '/' else '') +
-                        '/' + active[0] for active in self.get_active_nodes()]
+                        '/' + active[0] for active in launcher._active_nodes]
         
         should_node_run = f'{node.namespace}/{node.name}' not in active_nodes 
         return should_node_run
@@ -454,7 +455,7 @@ class Stack():
         """
         for c in composable_containers:
             node_desc = [ComposableNode(package=cn.pkg, plugin=cn.plugin, name=cn.name, namespace=cn.namespace, parameters=cn.ros_params, remappings=self.process_remaps(cn.remap))
-                         for cn in c.nodes if cn.action == STARTACTION or (cn.action == NOACTION and self.should_node_run(cn))]
+                         for cn in c.nodes if cn.action == STARTACTION or (cn.action == NOACTION and self.should_node_run(cn, launcher))]
 
             if node_desc:  # If node_desc is not empty
                 container = ComposableNodeContainer(
@@ -477,7 +478,7 @@ class Stack():
             launch_description (object): The launch description object.
         """
         for n in nodes:
-            if n.action == STARTACTION or (n.action == NOACTION and self.should_node_run(n)):
+            if n.action == STARTACTION or (n.action == NOACTION and self.should_node_run(n, launcher)):
                 launch_description.add_action(Node(
                     package=n.pkg,
                     executable=n.exec,

--- a/composer/muto_composer.py
+++ b/composer/muto_composer.py
@@ -127,7 +127,7 @@ class MutoComposer(Node):
                 )
                 self.publish_current_stack(resolved_stack)
                 self.publish_raw_stack(resolved_stack)
-                self.pipeline_execute("start")
+                self.pipeline_execute("start", json.loads(resolved_stack))
             else:
                 self.get_logger().error(
                     "No default stack received. Aborting bootstrap."
@@ -298,6 +298,8 @@ class MutoComposer(Node):
             self.get_logger().info(
                 "Archive manifest detected; running ProvisionPlugin and LaunchPlugin."
             )
+            self.current_stack = next_stack
+
         elif has_json_artifact:
             should_run_provision = False
             should_run_launch = True
@@ -350,7 +352,7 @@ class MutoComposer(Node):
             "should_run_provision": should_run_provision,
             "should_run_launch": should_run_launch,
         }
-        self.pipeline_execute(self.method, execution_context)
+        self.pipeline_execute(self.method, execution_context, self.current_stack)
 
     def merge(self, current_stack: dict, next_stack: dict) -> dict:
         """
@@ -372,7 +374,7 @@ class MutoComposer(Node):
         merged = stack_1.merge(stack_2)
         return merged.manifest
 
-    def pipeline_execute(self, pipeline_name: str, additional_context: dict = None):
+    def pipeline_execute(self, pipeline_name: str, additional_context: dict = None, stack_manifest=None):
         """
         Execute a specific pipeline by name with additional context.
 
@@ -385,7 +387,7 @@ class MutoComposer(Node):
             self.get_logger().info(
                 f"Executing pipeline: {pipeline_name} with context: {additional_context}"
             )
-            pipeline.execute_pipeline(additional_context=additional_context)
+            pipeline.execute_pipeline(additional_context=additional_context, next_manifest=stack_manifest)
         else:
             self.get_logger().warn(f"No pipeline found with name: {pipeline_name}")
 

--- a/composer/muto_composer.py
+++ b/composer/muto_composer.py
@@ -127,7 +127,7 @@ class MutoComposer(Node):
                 )
                 self.publish_current_stack(resolved_stack)
                 self.publish_raw_stack(resolved_stack)
-                self.pipeline_execute("start", json.loads(resolved_stack))
+                self.pipeline_execute("start", None, json.loads(resolved_stack))
             else:
                 self.get_logger().error(
                     "No default stack received. Aborting bootstrap."

--- a/composer/plugins/compose_plugin.py
+++ b/composer/plugins/compose_plugin.py
@@ -71,6 +71,12 @@ class MutoDefaultComposePlugin(Node):
             response.success = False
             response.err_msg = str(e)
             self.get_logger().error(f"Exception during compose: {e}")
+        
+        ## Simply chain the input to putput for now..
+        ## This plugin should be able to determine how 
+        ## the pipeline will continue to work i.e. apply policies
+        ## and transformations to the stack.
+        response.output.current = request.input.current
         return response
 
     def publish_composed_stack(self):

--- a/composer/plugins/launch_plugin.py
+++ b/composer/plugins/launch_plugin.py
@@ -108,10 +108,15 @@ class MutoDefaultLaunchPlugin(Node):
             return None, None, None, None
             
         # Determine type based on content_type or structure
-        content_type = parsed_payload.get("content_type")
+        metadata = parsed_payload.get("metadata")
+        content_type = None
+        if metadata is not None:
+            content_type = metadata.get("content_type")
         if content_type == "stack/archive":
-            launch_file = parsed_payload.get("launch_file")
-            command = parsed_payload.get("command", "launch")
+            launch = parsed_payload.get("launch", {})
+            props = launch.get("properties", {})
+            launch_file = props.get("launch_file")
+            command = props.get("command", "launch")
             return "stack/archive", parsed_payload, launch_file, command
         elif content_type == "stack/json":
             # For stack/json, the parsed_payload is the launch data

--- a/composer/plugins/launch_plugin.py
+++ b/composer/plugins/launch_plugin.py
@@ -127,9 +127,10 @@ class MutoDefaultLaunchPlugin(Node):
         else:
             return None, None, None, None
 
-    def _handle_stack_json_start(self, stack_data):
+    def _handle_stack_json_start(self, manifest):
         """Handle start for stack/json payload type."""
-        if stack_data:
+        if manifest:
+            stack_data = manifest.get("launch")
             stack = Stack(manifest=stack_data)
             stack.launch(self.launcher)
             return True

--- a/composer/utils/__init__.py
+++ b/composer/utils/__init__.py
@@ -1,0 +1,7 @@
+"""
+Utilities package for Eclipse Muto Composer.
+"""
+
+from .stack_parser import StackParser, create_stack_parser
+
+__all__ = ["StackParser", "create_stack_parser"]

--- a/composer/utils/stack_parser.py
+++ b/composer/utils/stack_parser.py
@@ -100,17 +100,7 @@ class StackParser:
         content_type = metadata.get("content_type")
         
         if content_type == "stack/json":
-            launch_data = payload.get("launch")
-            if isinstance(launch_data, dict):
-                self.logger.debug("Parsed direct stack/json format")
-                return launch_data
-            elif isinstance(launch_data, str):
-                try:
-                    parsed_data = json.loads(launch_data)
-                    self.logger.debug("Parsed direct stack/json from string")
-                    return parsed_data
-                except json.JSONDecodeError as e:
-                    self.logger.warning(f"Failed to parse stack JSON string: {e}")
+            return payload
                         
         return None
     

--- a/composer/utils/stack_parser.py
+++ b/composer/utils/stack_parser.py
@@ -1,0 +1,282 @@
+"""
+Stack Parser Utility for Eclipse Muto Composer
+
+This module provides utilities for parsing different stack payload formats
+including direct stack payloads, solution manifests, and archive formats.
+"""
+
+import json
+import base64
+import gzip
+import io
+from typing import Optional, Dict, Any
+import logging
+
+
+class StackParser:
+    """
+    Utility class for parsing and extracting stack definitions from various payload formats.
+    
+    Supports:
+    - Direct stack JSON payloads (new format)
+    - Archive stack payloads (new format) 
+    - Solution manifest payloads with embedded stack components (old format)
+    - Base64 encoded and compressed stack data
+    """
+    
+    def __init__(self, logger: Optional[logging.Logger] = None):
+        """
+        Initialize the StackParser.
+        
+        Args:
+            logger: Optional logger instance for debugging and error reporting
+        """
+        self.logger = logger or logging.getLogger(__name__)
+    
+    def parse_payload(self, payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """
+        Main entry point for parsing stack payloads.
+        
+        Args:
+            payload: The payload dictionary to parse
+            
+        Returns:
+            Parsed stack dictionary if successful, original payload if has "value" key, None otherwise
+            
+        Rules:
+        - If payload has a "value" key, return payload as-is (no parsing needed)
+        - Otherwise, attempt to extract stack from various formats
+        """
+        if not isinstance(payload, dict):
+            self.logger.warning("Payload is not a dictionary")
+            return None
+            
+        # If payload has a value key, return as-is (existing behavior)
+        if "value" in payload:
+            self.logger.debug("Payload contains 'value' key, returning as-is")
+            return payload
+            
+        # Try different parsing strategies in order of preference
+        # 1. Try new direct stack format (stack.json style)
+        stack = self._try_direct_stack_json(payload)
+        if stack:
+            return stack
+            
+        # 2. Try new archive format (stack-archive-example.json style)
+        stack = self._try_archive_format(payload)
+        if stack:
+            return stack
+            
+        # 3. Try old solution manifest format (talker-listener-archive-solution.json style)
+        stack = self._try_solution_manifest(payload)
+        if stack:
+            return stack
+
+        #if payload is dictionary and has node or composable return the payloadas is
+        if isinstance(payload, dict) and ("node" in payload or "composable" in payload):
+            self.logger.debug("Payload contains 'node' or 'composable', returning as-is")
+            return payload
+        
+        self.logger.warning("Could not parse stack from payload")
+        return None
+    
+    def _try_direct_stack_json(self, payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """
+        Try to parse payload as a direct stack/json definition.
+        
+        Direct stack format example (stack.json):
+        {
+            "metadata": {
+                "name": "...",
+                "content_type": "stack/json"
+            },
+            "launch": {
+                "node": [...],
+                "composable": [...]
+            }
+        }
+        """
+        metadata = payload.get("metadata", {})
+        content_type = metadata.get("content_type")
+        
+        if content_type == "stack/json":
+            launch_data = payload.get("launch")
+            if isinstance(launch_data, dict):
+                self.logger.debug("Parsed direct stack/json format")
+                return launch_data
+            elif isinstance(launch_data, str):
+                try:
+                    parsed_data = json.loads(launch_data)
+                    self.logger.debug("Parsed direct stack/json from string")
+                    return parsed_data
+                except json.JSONDecodeError as e:
+                    self.logger.warning(f"Failed to parse stack JSON string: {e}")
+                        
+        return None
+    
+    def _try_archive_format(self, payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """
+        Try to parse payload as an archive format stack.
+        
+        Archive format example (stack-archive-example.json):
+        {
+            "metadata": {
+                "name": "...",
+                "content_type": "stack/archive"
+            },
+            "launch": {
+                "data": "base64_encoded_compressed_data",
+                "properties": { ... }
+            }
+        }
+        """
+        metadata = payload.get("metadata", {})
+        content_type = metadata.get("content_type")
+        
+        if content_type == "stack/archive":
+            launch_data = payload.get("launch", {})
+            data_b64 = launch_data.get("data")
+            if data_b64:
+                try:
+                    # For archive format, we don't decode the data as JSON stack
+                    # Instead, we create a stack definition that references the archive
+                    archive_properties = launch_data.get("properties", {})
+                    
+                    # Create a stack that uses the archive properties
+                    result_stack = {
+                        "content_type": "stack/archive",
+                        "stack": data_b64,  # Keep as base64 for later processing
+                        "properties": archive_properties,
+                        "metadata": metadata,
+                    }
+                    
+                    # If there are launch-related properties, add them to the stack
+                    if "launch_file" in archive_properties:
+                        result_stack["launch_file"] = archive_properties["launch_file"]
+                    if "command" in archive_properties:
+                        result_stack["command"] = archive_properties["command"]
+                    if "launch_args" in archive_properties:
+                        result_stack["launch_args"] = archive_properties["launch_args"]
+                    
+                    self.logger.debug("Parsed stack/archive format")
+                    return result_stack
+                except Exception as exc:
+                    self.logger.warning(f"Failed to process archive stack data: {exc}")
+                    
+        return None
+    
+    def _try_solution_manifest(self, payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """
+        Try to parse payload as a solution manifest with embedded stack components.
+        
+        This handles the existing _extract_stack_from_solution logic for the old format.
+        Solution manifest format (talker-listener-archive-solution.json):
+        {
+            "spec": {
+                "components": [
+                    {
+                        "name": "...",
+                        "type": "muto-agent",
+                        "properties": {
+                            "type": "stack",
+                            "data": "base64_encoded_data"
+                        }
+                    }
+                ]
+            }
+        }
+        """
+        spec = payload.get("spec")
+        if not isinstance(spec, dict):
+            return None
+
+        components = spec.get("components", [])
+        if not isinstance(components, list):
+            return None
+
+        for component in components:
+            properties = component.get("properties", {})
+            if properties.get("type") != "stack":
+                continue
+                
+            data_b64 = properties.get("data")
+            if not data_b64:
+                continue
+
+            try:
+                stack = self._decode_base64_stack(data_b64)
+                if stack:
+                    self.logger.debug(f"Extracted stack from solution component '{component.get('name', '')}'")
+                    return stack
+            except Exception as exc:
+                self.logger.warning(
+                    f"Failed to decode stack component '{component.get('name', '')}' from solution: {exc}"
+                )
+                
+        return None
+    
+    def _decode_base64_stack(self, data_b64: str) -> Optional[Dict[str, Any]]:
+        """
+        Decode base64 encoded stack data, handling compression if present.
+        
+        Args:
+            data_b64: Base64 encoded stack data
+            
+        Returns:
+            Decoded stack dictionary if successful, None otherwise
+        """
+        try:
+            raw = base64.b64decode(data_b64)
+            
+            # Handle potential gzip compression
+            while True:
+                try:
+                    stack_json = raw.decode("utf-8")
+                    stack_dict = json.loads(stack_json)
+                    return stack_dict
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    # Check for gzip compression using magic numbers
+                    if len(raw) > 2 and raw[0] == 0x1F and raw[1] == 0x8B:  # gzip magic numbers
+                        with gzip.GzipFile(fileobj=io.BytesIO(raw)) as gz:
+                            raw = gz.read()
+                        continue
+                    raise
+                    
+        except (ValueError, json.JSONDecodeError, OSError) as exc:
+            self.logger.warning(f"Failed to decode base64 stack data: {exc}")
+            return None
+    
+    def validate_stack(self, stack: Dict[str, Any]) -> bool:
+        """
+        Validate that the parsed result is a valid stack definition.
+        
+        Args:
+            stack: Stack dictionary to validate
+            
+        Returns:
+            True if valid stack, False otherwise
+        """
+        if not isinstance(stack, dict):
+            return False
+            
+        # Basic validation - at least one of these should be present for a valid stack
+        required_fields = ["node", "composable", "launch_description_source", "artifact", "archive_properties"]
+        optional_fields = ["stackId", "name", "context", "on_start", "on_kill", "content_type"]
+        
+        has_required = any(field in stack for field in required_fields)
+        has_structure = any(field in stack for field in required_fields + optional_fields)
+        
+        return has_required or has_structure
+
+
+def create_stack_parser(logger: Optional[logging.Logger] = None) -> StackParser:
+    """
+    Factory function to create a StackParser instance.
+    
+    Args:
+        logger: Optional logger instance
+        
+    Returns:
+        StackParser instance
+    """
+    return StackParser(logger)

--- a/composer/utils/stack_parser.py
+++ b/composer/utils/stack_parser.py
@@ -134,34 +134,7 @@ class StackParser:
         content_type = metadata.get("content_type")
         
         if content_type == "stack/archive":
-            launch_data = payload.get("launch", {})
-            data_b64 = launch_data.get("data")
-            if data_b64:
-                try:
-                    # For archive format, we don't decode the data as JSON stack
-                    # Instead, we create a stack definition that references the archive
-                    archive_properties = launch_data.get("properties", {})
-                    
-                    # Create a stack that uses the archive properties
-                    result_stack = {
-                        "content_type": "stack/archive",
-                        "stack": data_b64,  # Keep as base64 for later processing
-                        "properties": archive_properties,
-                        "metadata": metadata,
-                    }
-                    
-                    # If there are launch-related properties, add them to the stack
-                    if "launch_file" in archive_properties:
-                        result_stack["launch_file"] = archive_properties["launch_file"]
-                    if "command" in archive_properties:
-                        result_stack["command"] = archive_properties["command"]
-                    if "launch_args" in archive_properties:
-                        result_stack["launch_args"] = archive_properties["launch_args"]
-                    
-                    self.logger.debug("Parsed stack/archive format")
-                    return result_stack
-                except Exception as exc:
-                    self.logger.warning(f"Failed to process archive stack data: {exc}")
+            return payload
                     
         return None
     

--- a/test/test_launch_plugin.py
+++ b/test/test_launch_plugin.py
@@ -1088,37 +1088,6 @@ class TestLaunchPlugin(unittest.TestCase):
         self.assertEqual(response.err_msg, "")
 
     @patch("composer.plugins.launch_plugin.Stack")
-    def test_handle_apply_stack_archive_content_type(self, mock_stack):
-        """Test handle_apply with stack/archive content_type."""
-        request = LaunchPlugin.Request()
-        response = LaunchPlugin.Response()
-        response.success = None
-        response.err_msg = None
-
-        # Payload with stack/archive content_type
-        archive_payload = {
-            "metadata": {
-                "name": "test-archive-stack",
-                "content_type": "stack/archive"
-            },
-            "launch": {
-                "data": "dGVzdCBkYXRh",
-                "properties": {
-                    "launch_file": "launch/test.launch.py"
-                }
-            }
-        }
-        request.input.current.stack = json.dumps(archive_payload)
-        request.input.current.source = json.dumps({})
-
-        self.node.handle_apply(request, response)
-
-        # For archive, it should use the full payload
-        mock_stack.assert_called_once_with(manifest=archive_payload)
-        self.assertTrue(response.success)
-        self.assertEqual(response.err_msg, "")
-
-    @patch("composer.plugins.launch_plugin.Stack")
     def test_handle_apply_raw_payload_type(self, mock_stack):
         """Test handle_apply with raw payload (node/composable)."""
         request = LaunchPlugin.Request()

--- a/test/test_launch_plugin.py
+++ b/test/test_launch_plugin.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock, patch
 import rclpy
 
 from composer.plugins.launch_plugin import MutoDefaultLaunchPlugin
+from muto_msgs.srv import LaunchPlugin
 
 
 class TestLaunchPlugin(unittest.TestCase):
@@ -550,6 +551,558 @@ class TestLaunchPlugin(unittest.TestCase):
             "No valid stack data found for apply operation.",
         )
         mock_stack.assert_not_called()
+
+    @patch.object(MutoDefaultLaunchPlugin, "_get_payload_type_and_data")
+    @patch.object(MutoDefaultLaunchPlugin, "_handle_stack_json_start")
+    @patch.object(MutoDefaultLaunchPlugin, "source_workspaces")
+    @patch("composer.plugins.launch_plugin.LaunchPlugin")
+    def test_handle_start_stack_json_content_type(self, mock_launch_plugin, mock_source_workspace, mock_handle_json, mock_get_payload):
+        """Test handle_start with stack/json content_type."""
+        request = mock_launch_plugin.request
+        request.start = True
+        response = mock_launch_plugin.response
+        response.success = None
+        response.err_msg = None
+
+        # Mock the payload parsing to return stack/json type
+        mock_get_payload.return_value = ("stack/json", {"node": [{"name": "test_node"}]}, None, None)
+        mock_handle_json.return_value = True
+
+        self.node.handle_start(request, response)
+
+        mock_source_workspace.assert_called_once()
+        mock_get_payload.assert_called_once()
+        mock_handle_json.assert_called_once()
+        self.assertTrue(response.success)
+        self.assertEqual(response.err_msg, "")
+
+    @patch.object(MutoDefaultLaunchPlugin, "_get_payload_type_and_data")
+    @patch.object(MutoDefaultLaunchPlugin, "_handle_archive_start")
+    @patch.object(MutoDefaultLaunchPlugin, "source_workspaces")
+    @patch("composer.plugins.launch_plugin.LaunchPlugin")
+    def test_handle_start_stack_archive_content_type(self, mock_launch_plugin, mock_source_workspace, mock_handle_archive, mock_get_payload):
+        """Test handle_start with stack/archive content_type."""
+        request = mock_launch_plugin.request
+        request.start = True
+        response = mock_launch_plugin.response
+        response.success = None
+        response.err_msg = None
+
+        # Mock the payload parsing to return stack/archive type
+        mock_get_payload.return_value = ("stack/archive", {"data": "dGVzdCBkYXRh"}, "launch/test.launch.py", "launch")
+        mock_handle_archive.return_value = True
+
+        self.node.handle_start(request, response)
+
+        mock_source_workspace.assert_called_once()
+        mock_get_payload.assert_called_once()
+        mock_handle_archive.assert_called_once_with("launch/test.launch.py")
+        self.assertTrue(response.success)
+        self.assertEqual(response.err_msg, "")
+
+    @patch.object(MutoDefaultLaunchPlugin, "_get_payload_type_and_data")
+    @patch.object(MutoDefaultLaunchPlugin, "_handle_raw_stack_start")
+    @patch.object(MutoDefaultLaunchPlugin, "source_workspaces")
+    @patch("composer.plugins.launch_plugin.LaunchPlugin")
+    def test_handle_start_raw_payload_type(self, mock_launch_plugin, mock_source_workspace, mock_handle_raw, mock_get_payload):
+        """Test handle_start with raw payload (node/composable)."""
+        request = mock_launch_plugin.request
+        request.start = True
+        response = mock_launch_plugin.response
+        response.success = None
+        response.err_msg = None
+
+        # Mock the payload parsing to return raw type
+        mock_get_payload.return_value = ("raw", {"node": [{"name": "test_node"}]}, None, None)
+        mock_handle_raw.return_value = True
+
+        self.node.handle_start(request, response)
+
+        mock_source_workspace.assert_called_once()
+        mock_get_payload.assert_called_once()
+        mock_handle_raw.assert_called_once()
+        self.assertTrue(response.success)
+        self.assertEqual(response.err_msg, "")
+
+    @patch.object(MutoDefaultLaunchPlugin, "_get_payload_type_and_data")
+    @patch.object(MutoDefaultLaunchPlugin, "_handle_legacy_script_start")
+    @patch.object(MutoDefaultLaunchPlugin, "source_workspaces")
+    @patch("composer.plugins.launch_plugin.LaunchPlugin")
+    def test_handle_start_unknown_content_type(self, mock_launch_plugin, mock_source_workspace, mock_handle_legacy, mock_get_payload):
+        """Test handle_start with unknown content_type falls back to legacy."""
+        request = mock_launch_plugin.request
+        request.start = True
+        response = mock_launch_plugin.response
+        response.success = None
+        response.err_msg = None
+
+        # Mock the payload parsing to return None (unknown type)
+        mock_get_payload.return_value = (None, None, None, None)
+        mock_handle_legacy.return_value = True
+
+        self.node.handle_start(request, response)
+
+        mock_source_workspace.assert_called_once()
+        mock_get_payload.assert_called_once()
+        mock_handle_legacy.assert_called_once()
+        self.assertTrue(response.success)
+        self.assertEqual(response.err_msg, "")
+
+    @patch.object(MutoDefaultLaunchPlugin, "_get_payload_type_and_data")
+    @patch.object(MutoDefaultLaunchPlugin, "_handle_legacy_script_start")
+    @patch.object(MutoDefaultLaunchPlugin, "source_workspaces")
+    @patch("composer.plugins.launch_plugin.LaunchPlugin")
+    def test_handle_start_missing_content_type(self, mock_launch_plugin, mock_source_workspace, mock_handle_legacy, mock_get_payload):
+        """Test handle_start with missing content_type falls back to legacy."""
+        request = mock_launch_plugin.request
+        request.start = True
+        response = mock_launch_plugin.response
+        response.success = None
+        response.err_msg = None
+
+        # Mock the payload parsing to return None (missing content_type)
+        mock_get_payload.return_value = (None, None, None, None)
+        mock_handle_legacy.return_value = True
+
+        self.node.handle_start(request, response)
+
+        mock_source_workspace.assert_called_once()
+        mock_get_payload.assert_called_once()
+        mock_handle_legacy.assert_called_once()
+        self.assertTrue(response.success)
+        self.assertEqual(response.err_msg, "")
+
+    @patch.object(MutoDefaultLaunchPlugin, "_get_payload_type_and_data")
+    @patch.object(MutoDefaultLaunchPlugin, "_handle_legacy_script_start")
+    @patch.object(MutoDefaultLaunchPlugin, "source_workspaces")
+    @patch("composer.plugins.launch_plugin.LaunchPlugin")
+    def test_handle_start_invalid_json_payload(self, mock_launch_plugin, mock_source_workspace, mock_handle_legacy, mock_get_payload):
+        """Test handle_start with invalid JSON payload falls back to legacy."""
+        request = mock_launch_plugin.request
+        request.start = True
+        response = mock_launch_plugin.response
+        response.success = None
+        response.err_msg = None
+
+        # Mock the payload parsing to return None (invalid payload)
+        mock_get_payload.return_value = (None, None, None, None)
+        mock_handle_legacy.return_value = True
+
+        self.node.handle_start(request, response)
+
+        mock_source_workspace.assert_called_once()
+        mock_get_payload.assert_called_once()
+        mock_handle_legacy.assert_called_once()
+        self.assertTrue(response.success)
+        self.assertEqual(response.err_msg, "")
+
+    @patch.object(MutoDefaultLaunchPlugin, "_get_payload_type_and_data")
+    @patch.object(MutoDefaultLaunchPlugin, "_handle_raw_stack_kill")
+    @patch("composer.plugins.launch_plugin.LaunchPlugin")
+    def test_handle_kill_stack_json_content_type(self, mock_launch_plugin, mock_handle_raw_kill, mock_get_payload):
+        """Test handle_kill with stack/json content_type."""
+        request = mock_launch_plugin.request
+        request.start = True
+        response = mock_launch_plugin.response
+        response.success = None
+        response.err_msg = None
+
+        # Mock the payload parsing to return stack/json type
+        mock_get_payload.return_value = ("stack/json", {"node": [{"name": "test_node"}]}, None, None)
+        mock_handle_raw_kill.return_value = True
+
+        self.node.handle_kill(request, response)
+
+        mock_get_payload.assert_called_once()
+        mock_handle_raw_kill.assert_called_once()
+        self.assertTrue(response.success)
+        self.assertEqual(response.err_msg, "Handle kill success")
+
+    @patch.object(MutoDefaultLaunchPlugin, "_get_payload_type_and_data")
+    @patch.object(MutoDefaultLaunchPlugin, "_handle_archive_kill")
+    @patch("composer.plugins.launch_plugin.LaunchPlugin")
+    def test_handle_kill_stack_archive_content_type(self, mock_launch_plugin, mock_handle_archive_kill, mock_get_payload):
+        """Test handle_kill with stack/archive content_type."""
+        request = mock_launch_plugin.request
+        request.start = True
+        response = mock_launch_plugin.response
+        response.success = None
+        response.err_msg = None
+
+        # Mock the payload parsing to return stack/archive type
+        mock_get_payload.return_value = ("stack/archive", {"data": "dGVzdCBkYXRh"}, "launch/test.launch.py", "launch")
+        mock_handle_archive_kill.return_value = True
+
+        self.node.handle_kill(request, response)
+
+        mock_get_payload.assert_called_once()
+        mock_handle_archive_kill.assert_called_once_with("launch/test.launch.py")
+        self.assertTrue(response.success)
+        self.assertEqual(response.err_msg, "Handle kill success")
+
+    @patch.object(MutoDefaultLaunchPlugin, "_get_payload_type_and_data")
+    @patch.object(MutoDefaultLaunchPlugin, "_handle_raw_stack_kill")
+    @patch("composer.plugins.launch_plugin.LaunchPlugin")
+    def test_handle_kill_raw_payload_type(self, mock_launch_plugin, mock_handle_raw_kill, mock_get_payload):
+        """Test handle_kill with raw payload (node/composable)."""
+        request = mock_launch_plugin.request
+        request.start = True
+        response = mock_launch_plugin.response
+        response.success = None
+        response.err_msg = None
+
+        # Mock the payload parsing to return raw type
+        mock_get_payload.return_value = ("raw", {"composable": [{"name": "test_composable"}]}, None, None)
+        mock_handle_raw_kill.return_value = True
+
+        self.node.handle_kill(request, response)
+
+        mock_get_payload.assert_called_once()
+        mock_handle_raw_kill.assert_called_once()
+        self.assertTrue(response.success)
+        self.assertEqual(response.err_msg, "Handle kill success")
+
+    @patch.object(MutoDefaultLaunchPlugin, "_get_payload_type_and_data")
+    @patch("composer.plugins.launch_plugin.Stack")
+    @patch("composer.plugins.launch_plugin.LaunchPlugin")
+    def test_handle_apply_stack_json_content_type(self, mock_launch_plugin, mock_stack, mock_get_payload):
+        """Test handle_apply with stack/json content_type."""
+        request = mock_launch_plugin.request
+        response = mock_launch_plugin.response
+        response.success = None
+        response.err_msg = None
+
+        # Mock the payload parsing to return stack/json type
+        mock_get_payload.return_value = ("stack/json", {"node": [{"name": "test_node"}]}, None, None)
+
+        self.node.handle_apply(request, response)
+
+        # For stack/json, it uses the stack_data as manifest
+        mock_stack.assert_called_once_with(manifest={"node": [{"name": "test_node"}]})
+        self.assertTrue(response.success)
+        self.assertEqual(response.err_msg, "")
+
+    @patch.object(MutoDefaultLaunchPlugin, "_get_payload_type_and_data")
+    @patch("composer.plugins.launch_plugin.Stack")
+    @patch("composer.plugins.launch_plugin.LaunchPlugin")
+    def test_handle_apply_stack_archive_content_type(self, mock_launch_plugin, mock_stack, mock_get_payload):
+        """Test handle_apply with stack/archive content_type."""
+        request = mock_launch_plugin.request
+        response = mock_launch_plugin.response
+        response.success = None
+        response.err_msg = None
+
+        # Mock the payload parsing to return stack/archive type
+        archive_payload = {
+            "metadata": {"name": "test-archive", "content_type": "stack/archive"},
+            "launch": {"data": "dGVzdA=="}
+        }
+        mock_get_payload.return_value = ("stack/archive", archive_payload, "launch/test.launch.py", "launch")
+
+        self.node.handle_apply(request, response)
+
+        # For archive, it uses the full payload
+        mock_stack.assert_called_once_with(manifest=archive_payload)
+        self.assertTrue(response.success)
+        self.assertEqual(response.err_msg, "")
+
+    @patch.object(MutoDefaultLaunchPlugin, "_get_payload_type_and_data")
+    @patch("composer.plugins.launch_plugin.Stack")
+    @patch("composer.plugins.launch_plugin.LaunchPlugin")
+    def test_handle_apply_raw_payload_type(self, mock_launch_plugin, mock_stack, mock_get_payload):
+        """Test handle_apply with raw payload (node/composable)."""
+        request = mock_launch_plugin.request
+        response = mock_launch_plugin.response
+        response.success = None
+        response.err_msg = None
+
+        # Mock the payload parsing to return raw type
+        mock_get_payload.return_value = ("raw", {"node": [{"name": "test_node"}]}, None, None)
+
+        self.node.handle_apply(request, response)
+
+        mock_stack.assert_called_once_with(manifest={"node": [{"name": "test_node"}]})
+        self.assertTrue(response.success)
+        self.assertEqual(response.err_msg, "")
+
+    @patch.object(MutoDefaultLaunchPlugin, "_get_payload_type_and_data")
+    @patch("composer.plugins.launch_plugin.Stack")
+    @patch("composer.plugins.launch_plugin.LaunchPlugin")
+    def test_handle_apply_unknown_content_type(self, mock_launch_plugin, mock_stack, mock_get_payload):
+        """Test handle_apply with unknown content_type uses full payload."""
+        request = mock_launch_plugin.request
+        response = mock_launch_plugin.response
+        response.success = None
+        response.err_msg = None
+
+        # Mock the payload parsing to return None (unknown type)
+        unknown_payload = {
+            "metadata": {"name": "test-unknown", "content_type": "unknown/type"},
+            "custom": {"data": "test"}
+        }
+        mock_get_payload.return_value = (None, None, None, None)
+        self.node.current_stack.stack = json.dumps(unknown_payload)
+
+        self.node.handle_apply(request, response)
+
+        # Should use the full payload as fallback
+        mock_stack.assert_called_once_with(manifest=unknown_payload)
+        self.assertTrue(response.success)
+        self.assertEqual(response.err_msg, "")
+
+    @patch("composer.plugins.launch_plugin.Stack")
+    def test_handle_apply_stack_archive_content_type(self, mock_stack):
+        """Test handle_apply with stack/archive content_type."""
+        request = LaunchPlugin.Request()
+        response = LaunchPlugin.Response()
+        response.success = None
+        response.err_msg = None
+
+        # Payload with stack/archive content_type
+        archive_payload = {
+            "metadata": {
+                "name": "test-archive-stack",
+                "content_type": "stack/archive"
+            },
+            "launch": {
+                "data": "dGVzdCBkYXRh",
+                "properties": {
+                    "launch_file": "launch/test.launch.py"
+                }
+            }
+        }
+        self.node.current_stack.stack = json.dumps(archive_payload)
+
+        self.node.handle_apply(request, response)
+
+        # For archive, it should use the full payload
+        mock_stack.assert_called_once_with(manifest=archive_payload)
+        self.assertTrue(response.success)
+        self.assertEqual(response.err_msg, "")
+
+    @patch("composer.plugins.launch_plugin.Stack")
+    def test_handle_apply_raw_payload_type(self, mock_stack):
+        """Test handle_apply with raw payload (node/composable)."""
+        request = LaunchPlugin.Request()
+        response = LaunchPlugin.Response()
+        response.success = None
+        response.err_msg = None
+
+        # Raw payload with node
+        raw_payload = {
+            "node": [{"name": "test_node"}]
+        }
+        self.node.current_stack.stack = json.dumps(raw_payload)
+
+        self.node.handle_apply(request, response)
+
+        mock_stack.assert_called_once_with(manifest=raw_payload)
+        self.assertTrue(response.success)
+        self.assertEqual(response.err_msg, "")
+
+    @patch("composer.plugins.launch_plugin.Stack")
+    def test_handle_apply_unknown_content_type(self, mock_stack):
+        """Test handle_apply with unknown content_type uses full payload."""
+        request = LaunchPlugin.Request()
+        response = LaunchPlugin.Response()
+        response.success = None
+        response.err_msg = None
+
+        # Payload with unknown content_type
+        unknown_payload = {
+            "metadata": {
+                "name": "test-unknown-stack",
+                "content_type": "unknown/type"
+            },
+            "custom": {
+                "data": "some_data"
+            }
+        }
+        self.node.current_stack.stack = json.dumps(unknown_payload)
+
+        self.node.handle_apply(request, response)
+
+        # Should use the full payload as fallback
+        mock_stack.assert_called_once_with(manifest=unknown_payload)
+        self.assertTrue(response.success)
+        self.assertEqual(response.err_msg, "")
+
+    @patch.object(MutoDefaultLaunchPlugin, "_get_payload_type_and_data")
+    @patch("composer.plugins.launch_plugin.Stack")
+    @patch("composer.plugins.launch_plugin.LaunchPlugin")
+    def test_handle_apply_raw_payload_type(self, mock_launch_plugin, mock_stack, mock_get_payload):
+        """Test handle_apply with raw payload (node/composable)."""
+        request = mock_launch_plugin.request
+        response = mock_launch_plugin.response
+        response.success = None
+        response.err_msg = None
+
+        # Raw payload with node
+        raw_payload = {
+            "node": [{"name": "test_node"}]
+        }
+        # Mock the payload parsing to return raw type
+        mock_get_payload.return_value = ("raw", raw_payload, None, None)
+
+        self.node.current_stack.stack = json.dumps(raw_payload)
+
+        self.node.handle_apply(request, response)
+
+        mock_stack.assert_called_once_with(manifest=raw_payload)
+        self.assertTrue(response.success)
+        self.assertEqual(response.err_msg, "")
+
+    @patch("composer.model.stack.Stack")
+    def test_handle_apply_unknown_content_type(self, mock_stack):
+        """Test handle_apply with unknown content_type uses full payload."""
+        request = LaunchPlugin.Request()
+        response = LaunchPlugin.Response()
+        response.success = None
+        response.err_msg = None
+
+        # Payload with unknown content_type
+        unknown_payload = {
+            "metadata": {
+                "name": "test-unknown-stack",
+                "content_type": "unknown/type"
+            },
+            "custom": {
+                "data": "some_data"
+            }
+        }
+        self.node.current_stack.stack = json.dumps(unknown_payload)
+
+        self.node.handle_apply(request, response)
+
+        # Should use the full payload as fallback
+        mock_stack.assert_called_once_with(manifest=unknown_payload)
+        self.assertTrue(response.success)
+        self.assertEqual(response.err_msg, "")
+
+    @patch("composer.model.stack.Stack")
+    @patch("muto_msgs.srv.LaunchPlugin")
+    def test_handle_apply_raw_payload_type(self, mock_launch_plugin, mock_stack):
+        """Test handle_apply with raw payload (node/composable)."""
+        request = mock_launch_plugin.request
+        response = mock_launch_plugin.response
+        response.success = None
+        response.err_msg = None
+
+        # Raw payload with node
+        raw_payload = {
+            "node": [{"name": "test_node"}]
+        }
+        self.node.current_stack.stack = json.dumps(raw_payload)
+
+        self.node.handle_apply(request, response)
+
+        mock_stack.assert_called_once_with(manifest=raw_payload)
+        self.assertTrue(response.success)
+        self.assertEqual(response.err_msg, "")
+
+    @patch("composer.model.stack.Stack")
+    @patch("muto_msgs.srv.LaunchPlugin")
+    def test_handle_apply_unknown_content_type(self, mock_launch_plugin, mock_stack):
+        """Test handle_apply with unknown content_type uses full payload."""
+        request = mock_launch_plugin.request
+        response = mock_launch_plugin.response
+        response.success = None
+        response.err_msg = None
+
+        # Payload with unknown content_type
+        unknown_payload = {
+            "metadata": {
+                "name": "test-unknown-stack",
+                "content_type": "unknown/type"
+            },
+            "custom": {
+                "data": "some_data"
+            }
+        }
+        self.node.current_stack.stack = json.dumps(unknown_payload)
+
+        self.node.handle_apply(request, response)
+
+        # Should use the full payload as fallback
+        mock_stack.assert_called_once_with(manifest=unknown_payload)
+        self.assertTrue(response.success)
+        self.assertEqual(response.err_msg, "")
+        """Test handle_apply with stack/archive content_type."""
+        request = mock_launch_plugin.request
+        response = mock_launch_plugin.response
+        response.success = None
+        response.err_msg = None
+
+        # Payload with stack/archive content_type
+        archive_payload = {
+            "metadata": {
+                "name": "test-archive-stack",
+                "content_type": "stack/archive"
+            },
+            "launch": {
+                "data": "dGVzdCBkYXRh",
+                "properties": {
+                    "launch_file": "launch/test.launch.py"
+                }
+            }
+        }
+        self.node.current_stack.stack = json.dumps(archive_payload)
+
+        self.node.handle_apply(request, response)
+
+        # For archive, it should use the full payload
+        mock_stack.assert_called_once_with(manifest=archive_payload)
+        self.assertTrue(response.success)
+        self.assertEqual(response.err_msg, "")
+
+    @patch("composer.plugins.launch_plugin.Stack")
+    @patch("composer.plugins.launch_plugin.LaunchPlugin")
+    def test_handle_apply_raw_payload_type(self, mock_launch_plugin, mock_stack):
+        """Test handle_apply with raw payload (node/composable)."""
+        request = mock_launch_plugin.request
+        response = mock_launch_plugin.response
+        response.success = None
+        response.err_msg = None
+
+        # Raw payload with node
+        raw_payload = {
+            "node": [{"name": "test_node"}]
+        }
+        self.node.current_stack.stack = json.dumps(raw_payload)
+
+        self.node.handle_apply(request, response)
+
+        mock_stack.assert_called_once_with(manifest=raw_payload)
+        self.assertTrue(response.success)
+        self.assertEqual(response.err_msg, "")
+
+    @patch("composer.plugins.launch_plugin.Stack")
+    @patch("composer.plugins.launch_plugin.LaunchPlugin")
+    def test_handle_apply_unknown_content_type(self, mock_launch_plugin, mock_stack):
+        """Test handle_apply with unknown content_type uses full payload."""
+        request = mock_launch_plugin.request
+        response = mock_launch_plugin.response
+        response.success = None
+        response.err_msg = None
+
+        # Payload with unknown content_type
+        unknown_payload = {
+            "metadata": {
+                "name": "test-unknown-stack",
+                "content_type": "unknown/type"
+            },
+            "custom": {
+                "data": "some_data"
+            }
+        }
+        self.node.current_stack.stack = json.dumps(unknown_payload)
+
+        self.node.handle_apply(request, response)
+
+        # Should use the full payload as fallback
+        mock_stack.assert_called_once_with(manifest=unknown_payload)
+        self.assertTrue(response.success)
+        self.assertEqual(response.err_msg, "")
 
 
 if __name__ == "__main__":

--- a/test/test_launch_plugin.py
+++ b/test/test_launch_plugin.py
@@ -228,7 +228,7 @@ class TestLaunchPlugin(unittest.TestCase):
         self.assertFalse(response.success)
         self.assertEqual(response.err_msg, "Start flag not set in request.")
 
-    @patch("subprocess.Popen")
+    @patch("composer.plugins.launch_plugin.subprocess.Popen")
     @patch.object(MutoDefaultLaunchPlugin, "find_file")
     @patch.object(MutoDefaultLaunchPlugin, "source_workspaces")
     @patch("composer.plugins.launch_plugin.LaunchPlugin")
@@ -249,6 +249,8 @@ class TestLaunchPlugin(unittest.TestCase):
             "mock_launch_description_source"
         )
         self.node.launch_arguments = ["test:=test_args"]
+        self.node.current_stack.on_start = None
+        self.node.current_stack.on_kill = None
         mock_find_file.return_value = "/path/to/launch_file.py"
 
         self.node.handle_start(request, response)
@@ -279,10 +281,12 @@ class TestLaunchPlugin(unittest.TestCase):
             "mock_launch_description_source"
         )
         self.node.launch_arguments = ["test:=test_args"]
+        self.node.current_stack.on_start = None
+        self.node.current_stack.on_kill = None
 
         mock_find_file.return_value = None
         self.node.handle_start(request, response)
-        self.assertRaises(FileNotFoundError)
+        # self.assertRaises(FileNotFoundError)
         mock_source_workspace.assert_called_once_with()
         mock_find_file.assert_called()
         mock_patch_asyncio.assert_not_called()
@@ -338,7 +342,7 @@ class TestLaunchPlugin(unittest.TestCase):
         self.assertFalse(response.success)
         self.assertEqual(
             response.err_msg,
-            "the JSON object must be str, bytes or bytearray, not MagicMock",
+            "No valid launch method found for the stack payload.",
         )
 
     @patch("subprocess.run")
@@ -411,6 +415,7 @@ class TestLaunchPlugin(unittest.TestCase):
         self.node.current_stack.name = "test_stack"
         self.node.current_stack.launch_description_source = "test_launch_file.launch.py"
         self.node.current_stack.on_kill = ""
+        self.node.current_stack.stack = json.dumps({})  # Add empty payload
 
         request = mock_launch_plugin.request
         request.start = True
@@ -542,7 +547,7 @@ class TestLaunchPlugin(unittest.TestCase):
         self.assertFalse(response.success)
         self.assertEqual(
             response.err_msg,
-            "the JSON object must be str, bytes or bytearray, not MagicMock",
+            "No valid stack data found for apply operation.",
         )
         mock_stack.assert_not_called()
 

--- a/test/test_muto_composer.py
+++ b/test/test_muto_composer.py
@@ -527,11 +527,12 @@ class TestMutoComposer(unittest.TestCase):
         }
         result = self.node.stack_parser.parse_payload(payload)
         self.assertIsNotNone(result)
-        self.assertEqual(result["content_type"], "stack/archive")
-        self.assertEqual(result["stack"], "dGVzdCBkYXRh")
-        self.assertEqual(result["launch_file"], "launch/test.launch.py")
-        self.assertEqual(result["command"], "launch")
-        self.assertEqual(result["launch_args"], [{"name": "arg1", "default": "val1"}])
+        # The parser returns the original payload structure
+        self.assertEqual(result["metadata"]["content_type"], "stack/archive")
+        self.assertEqual(result["launch"]["data"], "dGVzdCBkYXRh")
+        self.assertEqual(result["launch"]["properties"]["launch_file"], "launch/test.launch.py")
+        self.assertEqual(result["launch"]["properties"]["command"], "launch")
+        self.assertEqual(result["launch"]["properties"]["launch_args"], [{"name": "arg1", "default": "val1"}])
 
     def test_parse_payload_unparseable(self):
         """Test that parse_payload returns None for unparseable payloads"""

--- a/test/test_provision_plugin.py
+++ b/test/test_provision_plugin.py
@@ -35,12 +35,7 @@ class TestMutoProvisionPlugin(unittest.TestCase):
     def setUp(self):
         self.node = MutoProvisionPlugin()
         self.node.get_logger = MagicMock()
-        self.node.current_stack = MagicMock()
-        self.node.current_stack.name = "Test Stack"
-        self.node.current_stack.url = "http://example.com/repo.git"
-        self.node.current_stack.branch = "main"
-        self.node.current_stack.stack = json.dumps({})
-        self.node.current_stack.source = json.dumps({})
+        # Don't set current_stack here - let handle_provision parse it from the request
 
     def tearDown(self):
         self.node.destroy_node()
@@ -53,20 +48,28 @@ class TestMutoProvisionPlugin(unittest.TestCase):
     ):
         request = MagicMock()
         request.start = True
+        request.input.current.url = "http://github.com/composer.git"
+        request.input.current.branch = "main"
+        # Use structure matching talker-listener-xarchive.json
+        stack_data = {
+            "metadata": {
+                "name": "Test Stack",
+                "description": "A test stack",
+                "content_type": "stack/json"
+            },
+            "launch": {
+                "node": [{"name": "test_node"}]
+            }
+        }
+        request.input.current.stack = json.dumps(stack_data)
         response = MagicMock()
-        self.node.current_stack = MagicMock()
-        self.node.current_stack.url = "http://github.com/composer.git"
-        self.node.current_stack.branch = "main"
-        self.node.current_stack.stack = json.dumps({})
-        self.node.current_stack.source = json.dumps({})
-        self.node.current_stack.name = "Test Stack"
         self.node.is_up_to_date = False
 
         self.node.handle_provision(request, response)
 
         mock_from_git.assert_called_once_with(
-            repo_url=self.node.current_stack.url,
-            branch=self.node.current_stack.branch,
+            repo_url=request.input.current.url,
+            branch=request.input.current.branch,
         )
         mock_install_dependencies.assert_called_once()
         mock_build_workspace.assert_called_once()
@@ -81,20 +84,28 @@ class TestMutoProvisionPlugin(unittest.TestCase):
     ):
         request = MagicMock()
         request.start = True
+        request.input.current.url = "http://github.com/composer.git"
+        request.input.current.branch = "main" 
+        # Use structure matching talker-listener-xarchive.json
+        stack_data = {
+            "metadata": {
+                "name": "Test Stack",
+                "description": "A test stack",
+                "content_type": "stack/json"
+            },
+            "launch": {
+                "node": [{"name": "test_node"}]
+            }
+        }
+        request.input.current.stack = json.dumps(stack_data)
         response = MagicMock()
-        self.node.current_stack = MagicMock()
-        self.node.current_stack.url = "http://github.com/composer.git"
-        self.node.current_stack.branch = "main"
-        self.node.current_stack.stack = json.dumps({})
-        self.node.current_stack.source = json.dumps({})
-        self.node.current_stack.name = "Test Stack"
         self.node.is_up_to_date = True
 
         self.node.handle_provision(request, response)
 
         mock_from_git.assert_called_once_with(
-            repo_url=self.node.current_stack.url,
-            branch=self.node.current_stack.branch,
+            repo_url=request.input.current.url,
+            branch=request.input.current.branch,
         )
         mock_install_dependencies.assert_not_called()
         mock_build_workspace.assert_not_called()
@@ -109,21 +120,27 @@ class TestMutoProvisionPlugin(unittest.TestCase):
     ):
         request = MagicMock()
         request.start = True
+        request.input.current.url = ""
         response = MagicMock()
+        # Use real archive structure from talker-listener-xarchive.json
         artifact_manifest = {
             "metadata": {
-                "name": "test-artifact",
+                "name": "Muto Simple Talker-Listener Stack",
+                "description": "A simple talker-listener stack example",
                 "content_type": "stack/archive"
             },
             "launch": {
-                "data": "ZHVtbXk=",
+                "data": "ZHVtbXk=",  # base64 encoded dummy data
                 "properties": {
-                    "filename": "dummy.tar.gz"
+                    "algorithm": "sha256",
+                    "checksum": "553fd2dc7d0eb41e7d65c467d358e7962d3efbb0e2f2e4f8158e926a081f96d0",
+                    "launch_file": "launch/talker_listener.launch.py",
+                    "command": "launch",
+                    "flatten": True
                 }
             }
         }
-        self.node.current_stack.stack = json.dumps(artifact_manifest)
-        self.node.current_stack.url = ""
+        request.input.current.stack = json.dumps(artifact_manifest)
 
         def mark_dirty(_):
             self.node.is_up_to_date = False
@@ -145,21 +162,27 @@ class TestMutoProvisionPlugin(unittest.TestCase):
     ):
         request = MagicMock()
         request.start = True
+        request.input.current.url = ""
         response = MagicMock()
+        # Use real archive structure from talker-listener-xarchive.json
         artifact_manifest = {
             "metadata": {
-                "name": "test-artifact",
+                "name": "Muto Simple Talker-Listener Stack",
+                "description": "A simple talker-listener stack example",
                 "content_type": "stack/archive"
             },
             "launch": {
-                "data": "ZHVtbXk=",
+                "data": "ZHVtbXk=",  # base64 encoded dummy data
                 "properties": {
-                    "filename": "dummy.tar.gz"
+                    "algorithm": "sha256",
+                    "checksum": "553fd2dc7d0eb41e7d65c467d358e7962d3efbb0e2f2e4f8158e926a081f96d0",
+                    "launch_file": "launch/talker_listener.launch.py",
+                    "command": "launch",
+                    "flatten": True
                 }
             }
         }
-        self.node.current_stack.stack = json.dumps(artifact_manifest)
-        self.node.current_stack.url = ""
+        request.input.current.stack = json.dumps(artifact_manifest)
 
         def mark_clean(_):
             self.node.is_up_to_date = True
@@ -176,19 +199,24 @@ class TestMutoProvisionPlugin(unittest.TestCase):
     def test_handle_provision_no_artifact_or_repo(self):
         request = MagicMock()
         request.start = True
+        request.input.current.url = ""
+        # Use proper structure but no archive data and no repo URL
+        stack_data = {
+            "metadata": {
+                "name": "Test Stack",
+                "description": "A test stack without repo or archive"
+            },
+            "launch": {
+                "node": [{"name": "test_node"}]
+            }
+        }
+        request.input.current.stack = json.dumps(stack_data)
         response = MagicMock()
-        self.node.current_stack = MagicMock()
-        self.node.current_stack.url = ""
-        self.node.current_stack.stack = json.dumps({})
-        self.node.current_stack.name = "Test Stack"
 
         result = self.node.handle_provision(request, response)
 
-        self.assertFalse(result.success)
-        self.assertEqual(
-            result.err_msg,
-            "Stack does not define a repository or archive artifact.",
-        )
+        self.assertFalse(response.success)
+        self.assertEqual(response.err_msg, "Stack does not define a repository or archive artifact.")
 
     def test_handle_provision_start_false(self):
         request = MagicMock()
@@ -215,10 +243,20 @@ class TestMutoProvisionPlugin(unittest.TestCase):
     def test_handle_provision_exception(self, mock_from_git):
         request = MagicMock()
         request.start = True
+        request.input.current.url = "http://github.com/composer.git" 
+        request.input.current.branch = "main"
+        # Use proper structure
+        stack_data = {
+            "metadata": {
+                "name": "Test Stack",
+                "description": "A test stack"
+            },
+            "launch": {
+                "node": [{"name": "test_node"}]
+            }
+        }
+        request.input.current.stack = json.dumps(stack_data)
         response = MagicMock()
-        self.node.current_stack = MagicMock()
-        self.node.current_stack.stack = json.dumps({})
-        self.node.current_stack.name = "Test Stack"
         mock_from_git.side_effect = Exception("Test Exception")
 
         self.node.handle_provision(request, response)
@@ -378,8 +416,7 @@ class TestMutoProvisionPlugin(unittest.TestCase):
         mock_subprocess_run.assert_has_calls(expected_calls)
 
     def test_get_workspace_dir(self):
-        self.node.current_stack = MagicMock()
-        self.node.current_stack.name = "Test Stack"
+        self.node.current_stack = {"name": "Test Stack"}
 
         workspace_dir = self.node.get_workspace_dir()
 
@@ -406,14 +443,15 @@ class TestMutoProvisionPlugin(unittest.TestCase):
         mock_join,
         mock_exist,
     ):
-        self.node.current_stack = MagicMock()
+        self.node.current_stack = {"name": "Test Stack"}
+        mock_exist.return_value = True  # Mock that .git directory exists
         repo_url = "http://github.com/composer.git"
         branch = "main"
 
         self.node.from_git(repo_url, branch)
-        mock_update_repository.assert_called_once_with(mock_join(), "main")
+        mock_update_repository.assert_called_once_with(mock_join.return_value, "main")
         mock_clone_repository.assert_not_called()
-        mock_checkout_and_check_submodules.assert_called_once_with(mock_join(), "main")
+        mock_checkout_and_check_submodules.assert_called_once_with(mock_join.return_value, "main")
         mock_join.assert_called()
         mock_exist.assert_called_once()
 
@@ -498,10 +536,12 @@ class TestMutoProvisionPlugin(unittest.TestCase):
         )
 
         self.assertFalse(result)
+        # The actual path should be an os.path.join result
+        expected_submodule_path = os.path.join(target_dir, "submodule1")
         mock_run.assert_called_once_with(
             ["git", "checkout", "test_branch"],
             check=True,
-            cwd="/var/tmp/muto_workspaces/Test_Stack/submodule1",
+            cwd=expected_submodule_path,
         )
 
     @patch("subprocess.check_output")
@@ -524,30 +564,40 @@ class TestMutoProvisionPlugin(unittest.TestCase):
         """Test handle_provision with stack/json content_type falls back to git."""
         request = MagicMock()
         request.start = True
+        request.input.current.url = "http://example.com/repo.git"
+        request.input.current.branch = "main"
         response = MagicMock()
         
-        # Payload with stack/json content_type
-        json_manifest = {
-            "metadata": {
-                "name": "test-json-stack",
-                "content_type": "stack/json"
-            },
-            "launch": {
-                "node": [{"name": "test_node"}]
+        # Mock is_up_to_date to be False so dependencies and build are called
+        self.node.is_up_to_date = False
+        
+        # Mock the dependencies and build methods
+        with patch.object(self.node, 'install_dependencies') as mock_install, \
+             patch.object(self.node, 'build_workspace') as mock_build:
+            
+            # Payload with stack/json content_type using proper structure
+            json_manifest = {
+                "metadata": {
+                    "name": "test-json-stack",
+                    "description": "A test JSON stack",
+                    "content_type": "stack/json"
+                },
+                "launch": {
+                    "node": [{"name": "test_node"}]
+                }
             }
-        }
-        self.node.current_stack.stack = json.dumps(json_manifest)
-        self.node.current_stack.url = "http://example.com/repo.git"
-        self.node.current_stack.branch = "main"
+            request.input.current.stack = json.dumps(json_manifest)
 
-        self.node.handle_provision(request, response)
+            self.node.handle_provision(request, response)
 
-        # Should call from_git since stack/json doesn't have special provision handling
-        mock_from_git.assert_called_once_with(
-            repo_url="http://example.com/repo.git",
-            branch="main"
-        )
-        self.assertTrue(response.success)
+            # Should call from_git since stack/json doesn't have special provision handling
+            mock_from_git.assert_called_once_with(
+                repo_url="http://example.com/repo.git",
+                branch="main"
+            )
+            mock_install.assert_called_once()
+            mock_build.assert_called_once()
+            self.assertTrue(response.success)
 
     @patch.object(MutoProvisionPlugin, "from_git")
     def test_handle_provision_unknown_content_type(self, mock_from_git):
@@ -556,34 +606,47 @@ class TestMutoProvisionPlugin(unittest.TestCase):
         request.start = True
         response = MagicMock()
         
-        # Payload with unknown content_type
-        unknown_manifest = {
-            "metadata": {
-                "name": "test-unknown-stack",
-                "content_type": "unknown/type"
-            },
-            "custom": {
-                "data": "some_data"
+        # Set actual values instead of letting MagicMock create placeholders
+        request.input.current.url = "http://example.com/repo.git"
+        request.input.current.branch = "main"
+        
+        # Mock the dependencies and build methods since they might be called
+        with patch.object(self.node, 'install_dependencies') as mock_install, \
+             patch.object(self.node, 'build_workspace') as mock_build:
+            
+            # Set is_up_to_date to False so we can track the install/build calls
+            self.node.is_up_to_date = False
+        
+            # Payload with unknown content_type
+            unknown_manifest = {
+                "metadata": {
+                    "name": "test-unknown-stack",
+                    "content_type": "unknown/type"
+                },
+                "custom": {
+                    "data": "some_data"
+                }
             }
-        }
-        self.node.current_stack.stack = json.dumps(unknown_manifest)
-        self.node.current_stack.url = "http://example.com/repo.git"
-        self.node.current_stack.branch = "main"
+            request.input.current.stack = json.dumps(unknown_manifest)
 
-        self.node.handle_provision(request, response)
+            self.node.handle_provision(request, response)
 
-        # Should call from_git since unknown content_type doesn't have special handling
-        mock_from_git.assert_called_once_with(
-            repo_url="http://example.com/repo.git",
-            branch="main"
-        )
-        self.assertTrue(response.success)
+            # Should call from_git since unknown content_type doesn't have special handling
+            mock_from_git.assert_called_once_with(
+                repo_url="http://example.com/repo.git",
+                branch="main"
+            )
+            mock_install.assert_called_once()
+            mock_build.assert_called_once()
+            self.assertTrue(response.success)
 
     @patch.object(MutoProvisionPlugin, "from_git")
     def test_handle_provision_missing_content_type(self, mock_from_git):
         """Test handle_provision with missing content_type falls back to git."""
         request = MagicMock()
         request.start = True
+        request.input.current.url = "http://example.com/repo.git"
+        request.input.current.branch = "main"
         response = MagicMock()
         
         # Payload without content_type
@@ -595,9 +658,7 @@ class TestMutoProvisionPlugin(unittest.TestCase):
                 "data": "ZHVtbXk="
             }
         }
-        self.node.current_stack.stack = json.dumps(no_content_type_manifest)
-        self.node.current_stack.url = "http://example.com/repo.git"
-        self.node.current_stack.branch = "main"
+        request.input.current.stack = json.dumps(no_content_type_manifest)
 
         self.node.handle_provision(request, response)
 
@@ -613,21 +674,19 @@ class TestMutoProvisionPlugin(unittest.TestCase):
         """Test handle_provision with invalid JSON payload falls back to git."""
         request = MagicMock()
         request.start = True
+        request.input.current.url = "http://example.com/repo.git"
+        request.input.current.branch = "main"
         response = MagicMock()
         
-        # Invalid JSON in stack field - becomes empty dict
-        self.node.current_stack.stack = "invalid json {"
-        self.node.current_stack.url = "http://example.com/repo.git"
-        self.node.current_stack.branch = "main"
+        # Invalid JSON in stack field - becomes None when parsed
+        request.input.current.stack = "invalid json {"
 
         self.node.handle_provision(request, response)
 
-        # Should call from_git since parsed_payload will be None for empty dict
-        mock_from_git.assert_called_once_with(
-            repo_url="http://example.com/repo.git",
-            branch="main"
-        )
-        self.assertTrue(response.success)
+        # Should NOT call from_git since parsed stack will be None for invalid JSON
+        mock_from_git.assert_not_called()
+        self.assertFalse(response.success)
+        self.assertEqual(response.err_msg, "No current stack received.")
 
     @patch.object(MutoProvisionPlugin, "from_git")
     def test_handle_provision_missing_content_type(self, mock_from_git):
@@ -636,33 +695,46 @@ class TestMutoProvisionPlugin(unittest.TestCase):
         request.start = True
         response = MagicMock()
         
-        # Payload without content_type - parser returns None
-        no_content_type_manifest = {
-            "metadata": {
-                "name": "test-no-content-type-stack"
-            },
-            "launch": {
-                "data": "ZHVtbXk="
+        # Set actual values instead of letting MagicMock create placeholders
+        request.input.current.url = "http://example.com/repo.git"
+        request.input.current.branch = "main"
+        
+        # Mock the dependencies and build methods since they might be called
+        with patch.object(self.node, 'install_dependencies') as mock_install, \
+             patch.object(self.node, 'build_workspace') as mock_build:
+            
+            # Set is_up_to_date to False so we can track the install/build calls
+            self.node.is_up_to_date = False
+        
+            # Payload without content_type - parser returns None
+            no_content_type_manifest = {
+                "metadata": {
+                    "name": "test-no-content-type-stack"
+                },
+                "launch": {
+                    "data": "ZHVtbXk="
+                }
             }
-        }
-        self.node.current_stack.stack = json.dumps(no_content_type_manifest)
-        self.node.current_stack.url = "http://example.com/repo.git"
-        self.node.current_stack.branch = "main"
+            request.input.current.stack = json.dumps(no_content_type_manifest)
 
-        self.node.handle_provision(request, response)
+            self.node.handle_provision(request, response)
 
-        # Should call from_git since parser returns None for unknown format
-        mock_from_git.assert_called_once_with(
-            repo_url="http://example.com/repo.git",
-            branch="main"
-        )
-        self.assertTrue(response.success)
+            # Should call from_git since parser returns None for unknown format
+            mock_from_git.assert_called_once_with(
+                repo_url="http://example.com/repo.git",
+                branch="main"
+            )
+            mock_install.assert_called_once()
+            mock_build.assert_called_once()
+            self.assertTrue(response.success)
 
     @patch.object(MutoProvisionPlugin, "from_git")
     def test_handle_provision_no_metadata_falls_back_to_git(self, mock_from_git):
         """Test handle_provision with payload missing metadata falls back to git."""
         request = MagicMock()
         request.start = True
+        request.input.current.url = "http://example.com/repo.git"
+        request.input.current.branch = "main"
         response = MagicMock()
         
         # Payload without metadata - parser returns None
@@ -671,9 +743,7 @@ class TestMutoProvisionPlugin(unittest.TestCase):
                 "data": "ZHVtbXk="
             }
         }
-        self.node.current_stack.stack = json.dumps(no_metadata_payload)
-        self.node.current_stack.url = "http://example.com/repo.git"
-        self.node.current_stack.branch = "main"
+        request.input.current.stack = json.dumps(no_metadata_payload)
 
         self.node.handle_provision(request, response)
 
@@ -688,6 +758,7 @@ class TestMutoProvisionPlugin(unittest.TestCase):
         """Test handle_provision fails when stack/archive has no data or URL."""
         request = MagicMock()
         request.start = True
+        request.input.current.url = ""  # No URL
         response = MagicMock()
         
         # Archive payload with no data and no URL
@@ -702,8 +773,7 @@ class TestMutoProvisionPlugin(unittest.TestCase):
                 }
             }
         }
-        self.node.current_stack.stack = json.dumps(archive_manifest)
-        self.node.current_stack.url = ""  # No URL
+        request.input.current.stack = json.dumps(archive_manifest)
 
         self.node.handle_provision(request, response)
 
@@ -729,8 +799,10 @@ class TestMutoProvisionPlugin(unittest.TestCase):
                 }
             }
         }
-        self.node.current_stack.stack = json.dumps(archive_manifest)
-        self.node.current_stack.url = ""  # No URL
+        request.input.current.stack = json.dumps(archive_manifest)
+        request.input.current.source = json.dumps({
+            "url": ""  # No URL
+        })
 
         self.node.handle_provision(request, response)
 
@@ -745,21 +817,32 @@ class TestMutoProvisionPlugin(unittest.TestCase):
         request.start = True
         response = MagicMock()
         
-        # Payload without metadata
-        no_metadata_payload = {
-            "launch": {
-                "data": "ZHVtbXk="
+        # Set actual values instead of letting MagicMock create placeholders
+        request.input.current.url = "http://example.com/repo.git"
+        request.input.current.branch = "main"
+        
+        # Mock the dependencies and build methods since they might be called
+        with patch.object(self.node, 'install_dependencies') as mock_install, \
+             patch.object(self.node, 'build_workspace') as mock_build:
+            
+            # Set is_up_to_date to False so we can track the install/build calls
+            self.node.is_up_to_date = False
+        
+            # Payload without metadata
+            no_metadata_payload = {
+                "launch": {
+                    "data": "ZHVtbXk="
+                }
             }
-        }
-        self.node.current_stack.stack = json.dumps(no_metadata_payload)
-        self.node.current_stack.url = "http://example.com/repo.git"
-        self.node.current_stack.branch = "main"
+            request.input.current.stack = json.dumps(no_metadata_payload)
 
-        self.node.handle_provision(request, response)
+            self.node.handle_provision(request, response)
 
-        # Should call from_git since no metadata means no content_type check
-        mock_from_git.assert_called_once_with(
-            repo_url="http://example.com/repo.git",
-            branch="main"
-        )
-        self.assertTrue(response.success)
+            # Should call from_git since no metadata means no content_type check
+            mock_from_git.assert_called_once_with(
+                repo_url="http://example.com/repo.git",
+                branch="main"
+            )
+            mock_install.assert_called_once()
+            mock_build.assert_called_once()
+            self.assertTrue(response.success)

--- a/test/test_provision_plugin.py
+++ b/test/test_provision_plugin.py
@@ -111,9 +111,15 @@ class TestMutoProvisionPlugin(unittest.TestCase):
         request.start = True
         response = MagicMock()
         artifact_manifest = {
-            "artifact": {
-                "type": "archive",
+            "metadata": {
+                "name": "test-artifact",
+                "content_type": "stack/archive"
+            },
+            "launch": {
                 "data": "ZHVtbXk=",
+                "properties": {
+                    "filename": "dummy.tar.gz"
+                }
             }
         }
         self.node.current_stack.stack = json.dumps(artifact_manifest)
@@ -141,9 +147,15 @@ class TestMutoProvisionPlugin(unittest.TestCase):
         request.start = True
         response = MagicMock()
         artifact_manifest = {
-            "artifact": {
-                "type": "archive",
+            "metadata": {
+                "name": "test-artifact",
+                "content_type": "stack/archive"
+            },
+            "launch": {
                 "data": "ZHVtbXk=",
+                "properties": {
+                    "filename": "dummy.tar.gz"
+                }
             }
         }
         self.node.current_stack.stack = json.dumps(artifact_manifest)


### PR DESCRIPTION
This feature request provides teh follwoing updates:

1) A new stack manifest schema { metadata launch *}
2) Support for stack/archive (a stack with a ROS2 workspace)
3) Support for stack/json (an almots compatible json variant of ROS2 launch model)
4) Updates to pipelines
      pipeline plugins use a dataflow model where each uses the output of the previous
5) Test Fixes